### PR TITLE
fix(application): Init redux-persistor with manual persistence on server

### DIFF
--- a/modules/redux/store.ts
+++ b/modules/redux/store.ts
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useMemo } from 'react';
 import { applyMiddleware, createStore } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import { persistReducer, persistStore } from 'redux-persist';
+import { PersistorOptions, persistReducer, persistStore } from 'redux-persist';
 import thunkMiddleware from 'redux-thunk';
 
 import reducers from './rootReducer';
@@ -63,7 +63,10 @@ export const initializeStore = (preloadedState) => {
  */
 export function useStore(initialState: RootState) {
   const store = useMemo(() => initializeStore(initialState), [initialState]);
-  const persistor = persistStore(store);
+
+  // init presistor with paused persistence, see: https://github.com/UTDNebula/planner/issues/80
+  const persistor = persistStore(store, { manualPersist: true } as PersistorOptions);
+
   return {
     store,
     persistor,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import { AnimateSharedLayout } from 'framer-motion';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
@@ -81,6 +81,9 @@ function PageLayout({ Component, pageProps }) {
  */
 export default function NebulaApp({ Component, pageProps }: AppProps): JSX.Element {
   const { store, persistor } = useStore(pageProps.initialReduxState);
+
+  // manually resume persistence, see: https://github.com/UTDNebula/planner/issues/80
+  useEffect(persistor.persist, []);
 
   return (
     <AuthProvider>


### PR DESCRIPTION
Resolves #80 

## Changes

Toggle manual persistence when persistor inits and resume it on mount of root component to avoid accessing ``window`` object on server pre-render.