### PR TITLE
fix: Align button text with icon

### DIFF
--- a/components/credits/Button.tsx
+++ b/components/credits/Button.tsx
@@ -19,12 +19,10 @@ const Button: FC<ButtonProps> = ({
   return (
     <button
       {...props}
-      className={`${colorClasses[color]} flex items-center justify-center h-[50px] w-[200px] transition duration-200 ease-in-out rounded-[10px] ${className}`}
+      className={`${colorClasses[color]} flex items-center justify-center h-[50px] w-[200px] transition duration-200 ease-in-out rounded-[10px] ${className} font-medium text-white gap-x-2`}
     >
-      <span className="font-medium text-white">
-        {icon && <span className="mr-2">{icon}</span>}
-        {children}
-      </span>
+      {icon}
+      {children}
     </button>
   );
 };


### PR DESCRIPTION
## Overview

List the GitHub issues containing the issues relevant to this pull request.

This PR aligns the icon and any children within the button to ensure they are vertically centered. Closes #249.

## What Changed

Go more into detail about key files that were modified and why they were
updated. Do not list every file that was modified; only note the ones most
relevant to this feature or bug fix.

I removed the span that the icon and children were wrapped in, so that the flexbox can manage their layout. 

