### PR TITLE
fix: Firefox failing to add transfer credit

### DIFF
--- a/components/credits/CreditsForm.tsx
+++ b/components/credits/CreditsForm.tsx
@@ -40,7 +40,7 @@ const CreditsForm: FC = () => {
       dispatch(
         addCredit({
           utdCourseCode: credit,
-          semester: isTransfer ? undefined : convertSemesterToData(semester),
+          semester: isTransfer ? null : convertSemesterToData(semester),
         }),
       );
     }

--- a/components/credits/CreditsTable.tsx
+++ b/components/credits/CreditsTable.tsx
@@ -79,7 +79,7 @@ const CreditsTable: FC = () => {
             },
             {
               title: 'Transfer',
-              valueGetter: (credit) => (typeof credit.semester === 'undefined' ? 'Yes' : 'No'),
+              valueGetter: (credit) => (!credit.semester ? 'Yes' : 'No'),
             },
             {
               title: 'Semester',

--- a/components/credits/DataGrid.tsx
+++ b/components/credits/DataGrid.tsx
@@ -21,7 +21,7 @@ type InternalRowLayoutProps<T> = RowLayoutProps<T> & { row?: T };
 const RowLayout = <T extends { [key: string]: unknown }>({
   row,
   children,
-  onClick: rowOnClick,
+  onClick: rowOnClick = () => ({}),
   injectedComponent: { Element: InjectedComponent, onClick } = {
     Element: () => null,
     onClick: () => ({}),

--- a/modules/redux/creditsSlice.ts
+++ b/modules/redux/creditsSlice.ts
@@ -8,14 +8,15 @@ import { SemesterCode } from '../common/data';
  */
 
 /**
- * **A credit is considered transfer if its semester is undefined**
+ * **A credit is considered transfer if its semester is null** \
+ * **Firebase does not support 'undefined'
  */
 export type Credit = {
   utdCourseCode: string;
-  semester?: {
+  semester: {
     year: number;
     semester: SemesterCode;
-  };
+  } | null;
 };
 
 /**
@@ -25,11 +26,11 @@ export type Credit = {
  * - if they are both UTD credits and have the same semester
  */
 const areEqual = (credit1: Credit, credit2: Credit) => {
-  if (typeof credit1.semester !== typeof credit2.semester) {
+  if ((!credit1.semester && credit2.semester) || (credit1.semester && !credit2.semester)) {
     return false;
   }
 
-  if (typeof credit1.semester === 'undefined' && typeof credit2.semester === 'undefined') {
+  if (!credit1.semester && !credit2.semester) {
     return credit1.utdCourseCode === credit2.utdCourseCode;
   }
 


### PR DESCRIPTION
Firefox cannot handle 'undefined' values