### PR TITLE
fix: Ensure that multiple blank plans can be created in succession

### DIFF
--- a/components/template/Modal.tsx
+++ b/components/template/Modal.tsx
@@ -37,8 +37,7 @@ export default function TemplateModal({ setOpenTemplateModal }: TemplateModalPro
   const handleTemplateCreation = async (major: string) => {
     console.log({ major });
     if (major === 'empty') {
-      const newPlan: StudentPlan = dummyPlan;
-      newPlan.id = uuid();
+      const newPlan: StudentPlan = { ...dummyPlan, id: uuid() };
       dispatch(updatePlan(newPlan));
       return router.push(`/app/plans/${newPlan.id}`);
     }


### PR DESCRIPTION
I ran into a weird issue after creating a blank plan, going back to the home page, then attempting to create a second plan, where the 2nd plan would fail to be created due to updating a read only property. This change makes a copy of the dummy plan before assigning it a new id which seems to have fixed the issue