### PR TITLE
Clean Up Semesters State

### DIFF
--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -11,7 +11,6 @@
  * Adding DndContext hooks (eg. useDraggable) without considering 'data' property will cause unexpected behaviors
  */
 import { trpc } from '@/utils/trpc';
-import { useTaskQueue } from '@/utils/useTaskQueue';
 import {
   DndContext,
   DragOverlay,
@@ -37,7 +36,7 @@ import {
   DraggableCourse,
   Semester,
 } from './types';
-import { createNewYear, isSemCodeEqual } from '@/utils/utilFunctions';
+import { isSemCodeEqual } from '@/utils/utilFunctions';
 import { SemesterCode } from '@prisma/client';
 import Toolbar from './Toolbar';
 
@@ -46,8 +45,16 @@ export interface PlannerProps {
   degreeRequirements: DegreeRequirementGroup[];
   semesters: Semester[];
   showTransfer: boolean;
-  planId: string;
-  setSemesters: React.Dispatch<React.SetStateAction<Semester[]>>;
+  handleAddCourseToSemester: (targetSemester: Semester, newCourse: DraggableCourse) => void;
+  handleMoveCourseFromSemesterToSemester: (
+    originSemester: Semester,
+    destinationSemester: Semester,
+    courseToMove: DraggableCourse,
+  ) => void;
+
+  handleRemoveCourseFromSemester: (targetSemester: Semester, targetCourse: DraggableCourse) => void;
+  handleAddYear: () => void;
+  handleRemoveYear: () => void;
 }
 
 /** Controlled wrapper around course list and semester tiles */
@@ -55,8 +62,11 @@ export default function Planner({
   degreeRequirements,
   semesters,
   showTransfer,
-  setSemesters,
-  planId,
+  handleAddCourseToSemester,
+  handleMoveCourseFromSemesterToSemester,
+  handleRemoveCourseFromSemester,
+  handleAddYear,
+  handleRemoveYear,
 }: PlannerProps): JSX.Element {
   // Course that is currently being dragged
   const [activeCourse, setActiveCourse] = useState<ActiveDragData | null>(null);
@@ -71,242 +81,10 @@ export default function Planner({
     }),
   );
 
-  const utils = trpc.useContext();
-
   // Get credits to check if semester invalid
   const creditsQuery = trpc.credits.getCredits.useQuery(undefined, { staleTime: 10000000000 });
   const credits = creditsQuery.data;
 
-  const { addTask } = useTaskQueue({ shouldProcess: true });
-
-  const addCourse = trpc.plan.addCourseToSemester.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
-
-  const removeCourse = trpc.plan.removeCourseFromSemester.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
-
-  const moveCourse = trpc.plan.moveCourseFromSemester.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
-
-  const createYear = trpc.plan.addYear.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
-
-  const deleteYear = trpc.plan.deleteYear.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
-
-  const handleYearCreate = async ({ semesterIds }: { [key: string]: string[] }) => {
-    try {
-      await toast.promise(
-        createYear.mutateAsync({
-          planId,
-          semesterIds: semesterIds.map((id) => id),
-        }),
-        {
-          pending: 'Creating year...',
-          success: 'Year created!',
-          error: 'Error creating year',
-        },
-        {
-          autoClose: 1000,
-        },
-      );
-    } catch (error) {
-      console.error(error);
-    }
-  };
-  const handleYearDelete = async () => {
-    try {
-      // TODO: Handle deletion errors
-
-      await toast.promise(
-        deleteYear.mutateAsync(planId),
-        {
-          pending: 'Deleting year...',
-          success: 'Year deleted!',
-          error: 'Error deleting year',
-        },
-        {
-          autoClose: 1000,
-        },
-      );
-    } catch (error) {}
-  };
-
-  const handleAddCourse = async ({ semesterId, courseName }: { [key: string]: string }) => {
-    try {
-      await toast.promise(
-        addCourse.mutateAsync({ planId, semesterId, courseName }),
-        {
-          pending: 'Adding course ' + courseName + '...',
-          success: 'Added course ' + courseName + '!',
-          error: 'Error in adding ' + courseName,
-        },
-        {
-          autoClose: 1000,
-        },
-      );
-    } catch (error) {}
-  };
-
-  const handleRemoveCourse = async ({
-    semesterId: semesterId,
-    courseName: courseName,
-  }: {
-    [key: string]: string;
-  }) => {
-    try {
-      await toast.promise(
-        removeCourse.mutateAsync({ planId, semesterId, courseName }),
-        {
-          pending: 'Removing course ' + courseName + '...',
-          success: 'Removed course ' + courseName + '!',
-          error: 'Error in removing ' + courseName,
-        },
-        {
-          autoClose: 1000,
-        },
-      );
-    } catch (error) {}
-  };
-
-  const handleMoveCourse = async ({
-    oldSemesterId,
-    newSemesterId,
-    courseName,
-  }: {
-    [key: string]: string;
-  }) => {
-    try {
-      await toast.promise(
-        moveCourse.mutateAsync({ planId, oldSemesterId, newSemesterId, courseName }),
-        {
-          pending: 'Moving course ' + courseName + '...',
-          success: 'Moved course ' + courseName + '!',
-          error: 'Error while moving ' + courseName,
-        },
-        {
-          autoClose: 1000,
-        },
-      );
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const handleAddYear = () => {
-    const newYear: Semester[] = createNewYear(
-      semesters.length ? semesters[semesters.length - 1].code : { semester: 'u', year: 2022 },
-    );
-    const semesterIds = newYear.map((sem) => sem.id);
-    setSemesters([...semesters, ...newYear]);
-    addTask({
-      func: handleYearCreate,
-      args: { semesterIds: semesterIds.map((id) => id.toString()) },
-    });
-  };
-
-  const handleRemoveYear = () => {
-    setSemesters(semesters.filter((_, idx) => idx < semesters.length - 3));
-    addTask({ func: handleYearDelete, args: {} });
-  };
-
-  const handleRemoveCourseFromSemester = (
-    targetSemester: Semester,
-    targetCourse: DraggableCourse,
-  ) => {
-    setSemesters((semesters) =>
-      semesters.map((semester) => {
-        if (semester.id === targetSemester.id) {
-          return {
-            ...semester,
-            courses: semester.courses.filter((course) => course.id !== targetCourse.id),
-          };
-        }
-
-        return semester;
-      }),
-    );
-
-    const semesterId = targetSemester.id.toString();
-    const courseName = targetCourse.code;
-    addTask({ func: handleRemoveCourse, args: { semesterId, courseName } });
-  };
-
-  const handleAddCourseToSemester = (targetSemester: Semester, newCourse: DraggableCourse) => {
-    // check for duplicate course
-    const isDuplicate = Boolean(
-      targetSemester.courses.find((course) => course.code === newCourse.code),
-    );
-    if (isDuplicate) {
-      toast.warn(
-        `You're already taking ${newCourse.code} in ${targetSemester.code.year}${targetSemester.code.semester}`,
-      );
-      return;
-    }
-
-    setSemesters((semesters) =>
-      semesters.map((semester) =>
-        semester.id === targetSemester.id
-          ? { ...semester, courses: [...semester.courses, newCourse] }
-          : semester,
-      ),
-    );
-    const semesterId = targetSemester.id.toString();
-    const courseName = newCourse.code;
-    addTask({ func: handleAddCourse, args: { semesterId, courseName } });
-  };
-
-  const handleMoveCourseFromSemesterToSemester = (
-    originSemester: Semester,
-    destinationSemester: Semester,
-    courseToMove: DraggableCourse,
-  ) => {
-    const isDuplicate = Boolean(
-      destinationSemester.courses.find((course) => course.code === courseToMove.code),
-    );
-    if (isDuplicate) {
-      toast.warn(
-        `You're already taking ${courseToMove.code} in ${originSemester.code.year}${destinationSemester.code.semester}`,
-      );
-      return;
-    }
-    setSemesters((semesters) =>
-      semesters.map((semester) => {
-        if (semester.id === destinationSemester.id) {
-          return { ...semester, courses: [...semester.courses, courseToMove] };
-        }
-
-        if (semester.id === originSemester.id) {
-          return {
-            ...semester,
-            courses: semester.courses.filter((course) => course.id !== courseToMove.id),
-          };
-        }
-        return semester;
-      }),
-    );
-
-    const oldSemesterId = originSemester.id.toString();
-    const newSemesterId = destinationSemester.id.toString();
-    const courseName = courseToMove.code;
-
-    addTask({ func: handleMoveCourse, args: { oldSemesterId, newSemesterId, courseName } });
-  };
   const courses = useMemo(
     () => semesters.flatMap((sem) => sem.courses).map((course) => course.code),
     [semesters],

--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -89,6 +89,7 @@ export default function Planner({
     () => semesters.flatMap((sem) => sem.courses).map((course) => course.code),
     [semesters],
   );
+
   const handleOnDragStart = ({ active }: { active: Active }) => {
     const originData = active.data.current as DragEventOriginData;
     setActiveCourse({ from: originData.from, course: originData.course });
@@ -101,26 +102,17 @@ export default function Planner({
       const originData = active.data.current as DragEventOriginData;
       const destinationData = over.data.current as DragEventDestinationData;
 
-      // from semester -> current semester
-      // attempting to drop semester course on current tile
-      if (
-        originData.from === 'semester-tile' &&
-        destinationData.to === 'semester-tile' &&
-        originData.semester.id === destinationData.semester.id
-      ) {
-        toast.warn(
-          `You're already taking ${originData.course.code} in ${originData.semester.code.year}${originData.semester.code.semester}`,
-        );
-        return;
-      }
-
       // from course list -> semester
       if (originData.from === 'course-list' && destinationData.to === 'semester-tile') {
         handleAddCourseToSemester(destinationData.semester, originData.course);
       }
 
       // from semester -> another semester
-      if (originData.from === 'semester-tile' && destinationData.to === 'semester-tile') {
+      if (
+        originData.from === 'semester-tile' &&
+        destinationData.to === 'semester-tile' &&
+        originData.semester.id !== destinationData.semester.id
+      ) {
         handleMoveCourseFromSemesterToSemester(
           originData.semester,
           destinationData.semester,

--- a/src/components/planner/useSemesters.ts
+++ b/src/components/planner/useSemesters.ts
@@ -47,8 +47,6 @@ type SemestersReducerAction =
     };
 
 const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn => {
-  const utils = trpc.useContext();
-
   const { addTask } = useTaskQueue({ shouldProcess: true });
 
   const [semesters, dispatch] = useReducer<
@@ -114,35 +112,15 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
     [semesters],
   );
 
-  const addCourse = trpc.plan.addCourseToSemester.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
+  const addCourse = trpc.plan.addCourseToSemester.useMutation();
 
-  const removeCourse = trpc.plan.removeCourseFromSemester.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
+  const removeCourse = trpc.plan.removeCourseFromSemester.useMutation();
 
-  const moveCourse = trpc.plan.moveCourseFromSemester.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
+  const moveCourse = trpc.plan.moveCourseFromSemester.useMutation();
 
-  const createYear = trpc.plan.addYear.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
+  const createYear = trpc.plan.addYear.useMutation();
 
-  const deleteYear = trpc.plan.deleteYear.useMutation({
-    async onSuccess() {
-      await utils.plan.getPlanById.invalidate(planId);
-    },
-  });
+  const deleteYear = trpc.plan.deleteYear.useMutation();
 
   const handleAddYear = () => {
     const newYear: Semester[] = createNewYear(

--- a/src/components/planner/useSemesters.ts
+++ b/src/components/planner/useSemesters.ts
@@ -1,19 +1,107 @@
+import { trpc } from '@/utils/trpc';
+import { toast } from 'react-toastify';
+import { createNewYear } from '@/utils/utilFunctions';
 import { ObjectID } from 'bson';
-import { Dispatch, SetStateAction, useMemo, useState } from 'react';
-import { Plan, Semester } from './types';
+import { useMemo, useReducer } from 'react';
+import { Plan, Semester, DraggableCourse } from './types';
 import { customCourseSort } from './utils';
+import { useTaskQueue } from '@/utils/useTaskQueue';
 
 export interface useSemestersProps {
+  planId: string;
   plan?: Plan;
 }
 
 export interface useSemestersReturn {
   semesters: Semester[];
-  setSemesters: Dispatch<SetStateAction<Semester[]>>;
+  handleAddCourseToSemester: (targetSemester: Semester, newCourse: DraggableCourse) => void;
+  handleMoveCourseFromSemesterToSemester: (
+    originSemester: Semester,
+    destinationSemester: Semester,
+    courseToMove: DraggableCourse,
+  ) => void;
+
+  handleRemoveCourseFromSemester: (targetSemester: Semester, targetCourse: DraggableCourse) => void;
+  handleAddYear: () => void;
+  handleRemoveYear: () => void;
 }
 
-const useSemesters = ({ plan }: useSemestersProps) => {
-  const [semesters, setSemesters] = useState<Semester[]>(
+type SemestersReducerState = Semester[];
+type SemestersReducerAction =
+  | {
+      type: 'addCourseToSemester';
+      semesterId: string;
+      newCourse: DraggableCourse;
+    }
+  | {
+      type: 'addSemesters';
+      newSemesters: Semester[];
+    }
+  | { type: 'removeYear' }
+  | { type: 'removeCourseFromSemester'; semesterId: string; courseId: string }
+  | {
+      type: 'moveCourseFromSemesterToSemester';
+      originSemesterId: string;
+      destinationSemesterId: string;
+      course: DraggableCourse;
+    };
+
+const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn => {
+  const utils = trpc.useContext();
+
+  const { addTask } = useTaskQueue({ shouldProcess: true });
+
+  const [semesters, dispatch] = useReducer<
+    (state: SemestersReducerState, action: SemestersReducerAction) => Semester[]
+  >(
+    (state, action) => {
+      switch (action.type) {
+        case 'addSemesters':
+          return [...state, ...action.newSemesters];
+
+        case 'removeYear':
+          return [...state].slice(0, state.length - 3);
+
+        case 'addCourseToSemester':
+          return state.map((semester) =>
+            semester.id.toString() === action.semesterId
+              ? { ...semester, courses: [...semester.courses, action.newCourse] }
+              : semester,
+          );
+
+        case 'removeCourseFromSemester':
+          return state.map((semester) =>
+            semester.id.toString() === action.semesterId
+              ? {
+                  ...semester,
+                  courses: semester.courses.filter(
+                    (course) => course.id.toString() !== action.courseId,
+                  ),
+                }
+              : semester,
+          );
+
+        case 'moveCourseFromSemesterToSemester':
+          return state.map((semester) => {
+            if (semester.id.toString() === action.destinationSemesterId) {
+              return { ...semester, courses: [...semester.courses, action.course] };
+            }
+
+            if (semester.id.toString() === action.originSemesterId) {
+              return {
+                ...semester,
+                courses: semester.courses.filter(
+                  (course) => course.id.toString() !== action.course.id.toString(),
+                ),
+              };
+            }
+
+            return semester;
+          });
+        default:
+          return state;
+      }
+    },
     plan ? parsePlanSemestersFromPlan(plan) : [],
   );
 
@@ -26,7 +114,205 @@ const useSemesters = ({ plan }: useSemestersProps) => {
     [semesters],
   );
 
-  return { semesters: sortedSemesters, setSemesters };
+  const addCourse = trpc.plan.addCourseToSemester.useMutation({
+    async onSuccess() {
+      await utils.plan.getPlanById.invalidate(planId);
+    },
+  });
+
+  const removeCourse = trpc.plan.removeCourseFromSemester.useMutation({
+    async onSuccess() {
+      await utils.plan.getPlanById.invalidate(planId);
+    },
+  });
+
+  const moveCourse = trpc.plan.moveCourseFromSemester.useMutation({
+    async onSuccess() {
+      await utils.plan.getPlanById.invalidate(planId);
+    },
+  });
+
+  const createYear = trpc.plan.addYear.useMutation({
+    async onSuccess() {
+      await utils.plan.getPlanById.invalidate(planId);
+    },
+  });
+
+  const deleteYear = trpc.plan.deleteYear.useMutation({
+    async onSuccess() {
+      await utils.plan.getPlanById.invalidate(planId);
+    },
+  });
+
+  const handleAddYear = () => {
+    const newYear: Semester[] = createNewYear(
+      semesters.length ? semesters[semesters.length - 1].code : { semester: 'u', year: 2022 },
+    );
+    const semesterIds = newYear.map((sem) => sem.id);
+
+    dispatch({ type: 'addSemesters', newSemesters: newYear });
+
+    addTask({
+      func: ({ semesterIds }) =>
+        toast.promise(
+          createYear.mutateAsync({
+            planId,
+            semesterIds: semesterIds.map((id) => id),
+          }),
+          {
+            pending: 'Creating year...',
+            success: 'Year created!',
+            error: 'Error creating year',
+          },
+          {
+            autoClose: 1000,
+          },
+        ),
+      args: { semesterIds: semesterIds.map((id) => id.toString()) },
+    });
+  };
+
+  const handleRemoveYear = () => {
+    dispatch({ type: 'removeYear' });
+
+    addTask({
+      func: () =>
+        toast
+          .promise(
+            deleteYear.mutateAsync(planId),
+            {
+              pending: 'Deleting year...',
+              success: 'Year deleted!',
+              error: 'Error deleting year',
+            },
+            {
+              autoClose: 1000,
+            },
+          )
+          .catch((err) => console.error(err)),
+      args: {},
+    });
+  };
+
+  const handleRemoveCourseFromSemester = (
+    targetSemester: Semester,
+    targetCourse: DraggableCourse,
+  ) => {
+    dispatch({
+      type: 'removeCourseFromSemester',
+      courseId: targetCourse.id.toString(),
+      semesterId: targetSemester.id.toString(),
+    });
+
+    const semesterId = targetSemester.id.toString();
+    const courseName = targetCourse.code;
+
+    addTask({
+      func: ({ semesterId, courseName }) =>
+        toast
+          .promise(
+            removeCourse.mutateAsync({ planId, semesterId, courseName }),
+            {
+              pending: 'Removing course ' + courseName + '...',
+              success: 'Removed course ' + courseName + '!',
+              error: 'Error in removing ' + courseName,
+            },
+            {
+              autoClose: 1000,
+            },
+          )
+          .catch((err) => console.error(err)),
+      args: { semesterId, courseName },
+    });
+  };
+
+  const handleAddCourseToSemester = (targetSemester: Semester, newCourse: DraggableCourse) => {
+    // check for duplicate course
+    const isDuplicate = Boolean(
+      targetSemester.courses.find((course) => course.code === newCourse.code),
+    );
+    if (isDuplicate) {
+      toast.warn(
+        `You're already taking ${newCourse.code} in ${targetSemester.code.year}${targetSemester.code.semester}`,
+      );
+      return;
+    }
+
+    const semesterId = targetSemester.id.toString();
+    const courseName = newCourse.code;
+
+    dispatch({ type: 'addCourseToSemester', semesterId, newCourse });
+
+    addTask({
+      func: ({ semesterId, courseName }) =>
+        toast.promise(
+          addCourse.mutateAsync({ planId, semesterId, courseName }),
+          {
+            pending: 'Adding course ' + courseName + '...',
+            success: 'Added course ' + courseName + '!',
+            error: 'Error in adding ' + courseName,
+          },
+          {
+            autoClose: 1000,
+          },
+        ),
+      args: { semesterId, courseName },
+    });
+  };
+
+  const handleMoveCourseFromSemesterToSemester = (
+    originSemester: Semester,
+    destinationSemester: Semester,
+    courseToMove: DraggableCourse,
+  ) => {
+    const isDuplicate = Boolean(
+      destinationSemester.courses.find((course) => course.code === courseToMove.code),
+    );
+    if (isDuplicate) {
+      toast.warn(
+        `You're already taking ${courseToMove.code} in ${originSemester.code.year}${destinationSemester.code.semester}`,
+      );
+      return;
+    }
+
+    const oldSemesterId = originSemester.id.toString();
+    const newSemesterId = destinationSemester.id.toString();
+    const courseName = courseToMove.code;
+
+    dispatch({
+      type: 'moveCourseFromSemesterToSemester',
+      originSemesterId: oldSemesterId,
+      destinationSemesterId: newSemesterId,
+      course: courseToMove,
+    });
+
+    addTask({
+      func: ({ courseName, newSemesterId, oldSemesterId }) =>
+        toast
+          .promise(
+            moveCourse.mutateAsync({ planId, oldSemesterId, newSemesterId, courseName }),
+            {
+              pending: 'Moving course ' + courseName + '...',
+              success: 'Moved course ' + courseName + '!',
+              error: 'Error while moving ' + courseName,
+            },
+            {
+              autoClose: 1000,
+            },
+          )
+          .catch((err) => console.error(err)),
+      args: { oldSemesterId, newSemesterId, courseName },
+    });
+  };
+
+  return {
+    semesters: sortedSemesters,
+    handleAddCourseToSemester,
+    handleAddYear,
+    handleMoveCourseFromSemesterToSemester,
+    handleRemoveCourseFromSemester,
+    handleRemoveYear,
+  };
 };
 
 export default useSemesters;
@@ -34,7 +320,7 @@ export default useSemesters;
 const parsePlanSemestersFromPlan = (plan: Plan): Semester[] => {
   return plan.semesters.map((sem) => ({
     code: sem.code,
-    id: ObjectID.createFromHexString(sem.id),
+    id: new ObjectID(sem.id),
     courses: sem.courses.map((course: string) => ({
       id: new ObjectID(),
       code: course,

--- a/src/pages/app/plans/[planId].tsx
+++ b/src/pages/app/plans/[planId].tsx
@@ -24,7 +24,14 @@ export default function PlanDetailPage(
 ): JSX.Element {
   const { planId } = props;
   const { plan, validation, isLoading, handlePlanDelete } = usePlan({ planId });
-  const { semesters, setSemesters } = useSemesters({ plan });
+  const {
+    semesters,
+    handleAddCourseToSemester,
+    handleAddYear,
+    handleMoveCourseFromSemesterToSemester,
+    handleRemoveCourseFromSemester,
+    handleRemoveYear,
+  } = useSemesters({ plan, planId });
 
   const [showTransfer, setShowTransfer] = useState(true);
 
@@ -78,9 +85,12 @@ export default function PlanDetailPage(
       <Planner
         degreeRequirements={degreeData}
         semesters={semesters}
-        planId={planId}
         showTransfer={showTransfer}
-        setSemesters={setSemesters}
+        handleAddCourseToSemester={handleAddCourseToSemester}
+        handleAddYear={handleAddYear}
+        handleMoveCourseFromSemesterToSemester={handleMoveCourseFromSemesterToSemester}
+        handleRemoveCourseFromSemester={handleRemoveCourseFromSemester}
+        handleRemoveYear={handleRemoveYear}
       />
       <button onClick={handlePlanDelete}>Delete</button>
     </div>

--- a/src/utils/useTaskQueue.ts
+++ b/src/utils/useTaskQueue.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 
 export function useTaskQueue(params: { shouldProcess: boolean }): {
-  tasks: ReadonlyArray<Task>;
+  tasks: ReadonlyArray<Task<unknown>>;
   isProcessing: boolean;
-  addTask: (task: Task) => void;
+  addTask: <T>(task: Task<T>) => void;
 } {
   const [queue, setQueue] = React.useState<{
     isProcessing: boolean;
-    tasks: Array<Task>;
+    tasks: Array<Task<unknown>>;
   }>({ isProcessing: false, tasks: [] });
 
   React.useEffect(() => {
@@ -38,13 +38,13 @@ export function useTaskQueue(params: { shouldProcess: boolean }): {
     addTask: React.useCallback((task) => {
       setQueue((prev) => ({
         isProcessing: prev.isProcessing,
-        tasks: [...prev.tasks, task],
+        tasks: [...prev.tasks, task] as Task<unknown>[],
       }));
     }, []),
   };
 }
 
-export type Task = {
-  func: (args: any) => Promise<void>;
-  args: { [key: string]: unknown };
+export type Task<T> = {
+  func: (args: T) => Promise<unknown>;
+  args: T;
 };


### PR DESCRIPTION
- Move all semesters state/mutations into useSemesters
- Manage semesters state with useReducer
- Move Planner.tsx back to using callbacks
- Make useTaskQueue tasks generic for type safety between ``funcs`` and ``args``
- Delete unnecessary toast when dropping course onto semester it was dragged from