### PR TITLE
Move Semesters State Into Context, Selectable Courses, Memoization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@next-auth/prisma-adapter": "^1.0.5",
         "@next/bundle-analyzer": "^13.1.6",
         "@prisma/client": "^4.9.0",
+        "@radix-ui/react-checkbox": "^1.0.1",
         "@radix-ui/react-dropdown-menu": "2.0.2",
         "@radix-ui/react-switch": "1.0.1",
         "@react-pdf/renderer": "^3.0.3",
@@ -4002,6 +4003,26 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.1.tgz",
+      "integrity": "sha512-TisH0B8hWmYP3ONRduYCyN04rR9yLPIw/Rwyn1RoC1suSoGCa8Wn+YPdSSSarSszeIbcg3p2lBkDp2XXit4sZw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "@radix-ui/react-use-previous": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -33616,6 +33637,22 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.1"
+      }
+    },
+    "@radix-ui/react-checkbox": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.1.tgz",
+      "integrity": "sha512-TisH0B8hWmYP3ONRduYCyN04rR9yLPIw/Rwyn1RoC1suSoGCa8Wn+YPdSSSarSszeIbcg3p2lBkDp2XXit4sZw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "@radix-ui/react-use-previous": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0"
       }
     },
     "@radix-ui/react-collection": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@next-auth/prisma-adapter": "^1.0.5",
     "@next/bundle-analyzer": "^13.1.6",
     "@prisma/client": "^4.9.0",
+    "@radix-ui/react-checkbox": "^1.0.1",
     "@radix-ui/react-dropdown-menu": "2.0.2",
     "@radix-ui/react-switch": "1.0.1",
     "@react-pdf/renderer": "^3.0.3",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -31,7 +31,7 @@ const Button: FC<ButtonProps> = ({
       className={`${colorClasses[color]} ${sizeClasses[size]} flex h-fit w-fit items-center justify-center rounded-md font-medium transition duration-200 ease-in-out ${className}`}
     >
       {icon}
-      {children}
+      <span className="whitespace-nowrap">{children}</span>
     </button>
   );
 };

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -31,7 +31,7 @@ const Button: FC<ButtonProps> = ({
       className={`${colorClasses[color]} ${sizeClasses[size]} flex h-fit w-fit items-center justify-center rounded-md font-medium transition duration-200 ease-in-out ${className}`}
     >
       {icon}
-      <span className="whitespace-nowrap">{children}</span>
+      {children}
     </button>
   );
 };

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+import * as RCheckbox from '@radix-ui/react-checkbox';
+import CheckIcon from '@/icons/CheckIcon';
+
+export type CheckboxProps = RCheckbox.CheckboxProps;
+
+const Checkbox: FC<CheckboxProps> = ({ className = '', ...props }) => (
+  <RCheckbox.Root
+    className={`h-5 w-5 overflow-hidden rounded-md border-1.25 border-neutral-300 bg-generic-white ${className}`}
+    {...props}
+  >
+    <RCheckbox.Indicator>
+      <div className="flex h-full w-full animate-[checkboxCheckmark_0.2s] items-center justify-center bg-primary">
+        <CheckIcon className="h-3 w-3 text-generic-white" />
+      </div>
+    </RCheckbox.Indicator>
+  </RCheckbox.Root>
+);
+
+export default Checkbox;

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,4 +1,4 @@
-import * as Switch from '@radix-ui/react-switch';
+import * as RSwitch from '@radix-ui/react-switch';
 import { FC } from 'react';
 
 const rootSizeClasses = {
@@ -9,21 +9,21 @@ const thumbSizeClasses = {
   small: 'h-[14px] w-[14px]',
 };
 
-export interface ToggleProps extends Switch.SwitchProps {
+export interface SwitchProps extends RSwitch.SwitchProps {
   size?: keyof typeof rootSizeClasses;
 }
 
-const Toggle: FC<ToggleProps> = ({ size = 'small', ...props }) => {
+const Switch: FC<SwitchProps> = ({ size = 'small', ...props }) => {
   return (
-    <Switch.Root
+    <RSwitch.Root
       {...props}
       className={`${rootSizeClasses[size]} relative rounded-full bg-neutral-300 data-[state=checked]:bg-primary`}
     >
-      <Switch.Thumb
+      <RSwitch.Thumb
         className={`${thumbSizeClasses[size]} duration-400 block h-[14px] w-[14px] translate-x-[1px] transform rounded-full bg-generic-white transition-transform will-change-transform data-[state=checked]:translate-x-[10px]`}
       />
-    </Switch.Root>
+    </RSwitch.Root>
   );
 };
 
-export default Toggle;
+export default Switch;

--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -21,7 +21,6 @@ import {
   Active,
   Over,
 } from '@dnd-kit/core';
-import { toast } from 'react-toastify';
 import React, { useMemo, useState } from 'react';
 
 import CourseSelectorContainer from './Sidebar/Sidebar';
@@ -33,42 +32,33 @@ import {
   DragEventDestinationData,
   DragEventOriginData,
   DraggableCourse,
-  Semester,
 } from './types';
 import { isSemCodeEqual } from '@/utils/utilFunctions';
 import { SemesterCode } from '@prisma/client';
 import { DegreeRequirements } from './Sidebar/types';
 
 import Toolbar from './Toolbar';
+import { useSemestersContext } from './SemesterContext';
 
 /** PlannerTool Props */
 export interface PlannerProps {
   degreeRequirements: DegreeRequirements;
-  semesters: Semester[];
   showTransfer: boolean;
-  handleAddCourseToSemester: (targetSemester: Semester, newCourse: DraggableCourse) => void;
-  handleMoveCourseFromSemesterToSemester: (
-    originSemester: Semester,
-    destinationSemester: Semester,
-    courseToMove: DraggableCourse,
-  ) => void;
-
-  handleRemoveCourseFromSemester: (targetSemester: Semester, targetCourse: DraggableCourse) => void;
-  handleAddYear: () => void;
-  handleRemoveYear: () => void;
 }
 
 /** Controlled wrapper around course list and semester tiles */
-export default function Planner({
-  degreeRequirements,
-  semesters,
-  showTransfer,
-  handleAddCourseToSemester,
-  handleMoveCourseFromSemesterToSemester,
-  handleRemoveCourseFromSemester,
-  handleAddYear,
-  handleRemoveYear,
-}: PlannerProps): JSX.Element {
+export default function Planner({ degreeRequirements, showTransfer }: PlannerProps): JSX.Element {
+  const {
+    semesters,
+    handleAddCourseToSemester,
+    handleAddYear,
+    handleMoveCourseFromSemesterToSemester,
+    handleRemoveCourseFromSemester,
+    handleRemoveYear,
+    selectedCourseCount,
+  } = useSemestersContext();
+
+  console.log('SELECTED COURSE COUNT: ' + selectedCourseCount);
   // Course that is currently being dragged
   const [activeCourse, setActiveCourse] = useState<ActiveDragData | null>(null);
 
@@ -151,7 +141,7 @@ export default function Planner({
         <section className="flex min-h-fit w-fit flex-col gap-y-6">
           <Toolbar title="Plan Your Courses" major="Computer Science" />
 
-          <section className="grid h-auto w-fit grid-cols-3 gap-[32px]">
+          <section className="flex h-auto w-fit flex-wrap gap-5">
             {semesters.map((semester) => {
               // Get map of credits (faster to query later down the line)
               const creditsMap: {
@@ -212,7 +202,6 @@ export default function Planner({
 
               return (
                 <DroppableSemesterTile
-                  onRemoveCourse={handleRemoveCourseFromSemester}
                   key={semester.id.toString()}
                   dropId={`semester-${semester.id}`}
                   getSemesterCourseDragId={(course, semester) =>

--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -44,11 +44,10 @@ import SelectedCoursesToast from './SelectedCoursesToast';
 /** PlannerTool Props */
 export interface PlannerProps {
   degreeRequirements: DegreeRequirements;
-  showTransfer: boolean;
 }
 
 /** Controlled wrapper around course list and semester tiles */
-export default function Planner({ degreeRequirements, showTransfer }: PlannerProps): JSX.Element {
+export default function Planner({ degreeRequirements }: PlannerProps): JSX.Element {
   const {
     semesters,
     handleAddCourseToSemester,
@@ -60,6 +59,9 @@ export default function Planner({ degreeRequirements, showTransfer }: PlannerPro
     handleSelectCourses,
     handleDeleteAllSelectedCourses,
   } = useSemestersContext();
+
+  // toggle transfered courses state
+  const [showTransfer, setShowTransfer] = useState(true);
 
   // Course that is currently being dragged
   const [activeCourse, setActiveCourse] = useState<ActiveDragData | null>(null);
@@ -154,7 +156,12 @@ export default function Planner({ degreeRequirements, showTransfer }: PlannerPro
         </DragOverlay>
 
         <section className="mt-[150px] flex min-h-fit w-fit flex-col gap-y-6">
-          <Toolbar title="Plan Your Courses" major="Computer Science" />
+          <Toolbar
+            title="Plan Your Courses"
+            major="Computer Science"
+            showTransfer={showTransfer}
+            toggleShowTransfer={() => setShowTransfer(!showTransfer)}
+          />
 
           <section className="flex h-auto w-fit flex-wrap gap-5">
             {semesters.map((semester) => {

--- a/src/components/planner/SelectedCoursesToast.tsx
+++ b/src/components/planner/SelectedCoursesToast.tsx
@@ -1,0 +1,67 @@
+import CursorClickIcon from '@/icons/CursorClickIcon';
+import DeleteIcon from '@/icons/DeleteIcon';
+import { AnimatePresence, motion } from 'framer-motion';
+import { FC } from 'react';
+import Button from '../Button';
+import Checkbox from '../Checkbox';
+
+export interface SelectedCoursesToastProps {
+  show: boolean;
+  selectedCount: number;
+  deselectAllCourses: () => void;
+  deleteSelectedCourses: () => void;
+  selectAllCourses: () => void;
+  areAllCoursesSelected: boolean;
+}
+
+const SelectedCoursesToast: FC<SelectedCoursesToastProps> = ({
+  show,
+  selectedCount,
+  deleteSelectedCourses,
+  deselectAllCourses,
+  selectAllCourses,
+  areAllCoursesSelected,
+}) => (
+  <AnimatePresence>
+    {show && (
+      <motion.div
+        className="fixed top-11 left-1/2 -translate-x-1/2 transform"
+        initial={{ y: -120 }}
+        animate={{ y: 0 }}
+        exit={{ y: -120 }}
+      >
+        <div className="flex items-center gap-x-4 overflow-hidden rounded-md border border-neutral-300 bg-generic-white px-5 py-4">
+          <Checkbox
+            defaultChecked
+            style={{ width: '20px', height: '20px' }}
+            onClick={deselectAllCourses}
+          />
+
+          <span className="text-lg font-semibold text-neutral-900">
+            {selectedCount} Courses Selected
+          </span>
+
+          <Button
+            size="medium"
+            color="secondary"
+            icon={<DeleteIcon />}
+            onClick={deleteSelectedCourses}
+          >
+            Delete
+          </Button>
+
+          <Button
+            size="medium"
+            color="primary"
+            icon={<CursorClickIcon stroke="#fff" />}
+            onClick={areAllCoursesSelected ? deselectAllCourses : selectAllCourses}
+          >
+            {areAllCoursesSelected ? 'Deselect All' : 'Select All'}
+          </Button>
+        </div>
+      </motion.div>
+    )}
+  </AnimatePresence>
+);
+
+export default SelectedCoursesToast;

--- a/src/components/planner/SemesterContext.tsx
+++ b/src/components/planner/SemesterContext.tsx
@@ -2,32 +2,61 @@ import { trpc } from '@/utils/trpc';
 import { toast } from 'react-toastify';
 import { createNewYear } from '@/utils/utilFunctions';
 import { ObjectID } from 'bson';
-import { useMemo, useReducer } from 'react';
+import { createContext, FC, useContext, useMemo, useReducer, useState } from 'react';
 import { Plan, Semester, DraggableCourse } from './types';
 import { customCourseSort } from './utils';
 import { useTaskQueue } from '@/utils/useTaskQueue';
 
-export interface useSemestersProps {
-  planId: string;
-  plan?: Plan;
-}
-
-export interface useSemestersReturn {
+export interface SemestersContextState {
   semesters: Semester[];
+  selectedCourseCount: number;
+  handleAddSelectedCourses: AddSelectedCoursesHandler;
+  handleRemoveSelectedCourse: RemoveSelectedCourseHandler;
   handleAddCourseToSemester: (targetSemester: Semester, newCourse: DraggableCourse) => void;
   handleMoveCourseFromSemesterToSemester: (
     originSemester: Semester,
     destinationSemester: Semester,
     courseToMove: DraggableCourse,
   ) => void;
-
   handleRemoveCourseFromSemester: (targetSemester: Semester, targetCourse: DraggableCourse) => void;
   handleAddYear: () => void;
   handleRemoveYear: () => void;
+  handleDeleteAllCoursesFromSemester: (semester: Semester) => void;
 }
 
-type SemestersReducerState = Semester[];
-type SemestersReducerAction =
+export const SemestersContext = createContext<SemestersContextState | null>(null);
+
+export const useSemestersContext = (): SemestersContextState => {
+  const ctx = useContext(SemestersContext);
+
+  if (ctx === null) {
+    throw new Error('SemestersContext consumers used outside provider');
+  }
+
+  return ctx;
+};
+
+export interface SemestersContextProviderProps {
+  planId: string;
+  plan: Plan;
+}
+
+export interface useSemestersProps {
+  planId: string;
+  plan?: Plan;
+}
+
+export type AddSelectedCoursesHandler = (courses: SelectedCourse[]) => void;
+
+export type RemoveSelectedCourseHandler = (course: SelectedCourse) => void;
+
+export type SelectedCourse = { courseId: string; semesterId: string };
+
+export type SelectedCoursesState = SelectedCourse[];
+
+export type SemestersReducerState = Semester[];
+
+export type SemestersReducerAction =
   | {
       type: 'addCourseToSemester';
       semesterId: string;
@@ -44,12 +73,43 @@ type SemestersReducerAction =
       originSemesterId: string;
       destinationSemesterId: string;
       course: DraggableCourse;
+    }
+  | {
+      type: 'deleteAllCoursesFromSemester';
+      semesterId: string;
     };
 
-const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn => {
+export const SemestersContextProvider: FC<SemestersContextProviderProps> = ({
+  planId,
+  plan,
+  children,
+}) => {
   const { addTask } = useTaskQueue({ shouldProcess: true });
 
-  const [semesters, dispatch] = useReducer<
+  const [selectedCourses, setSelectedCourses] = useState<SelectedCoursesState>([]);
+
+  const handleAddSelectedCourses = (courses: SelectedCourse[]) => {
+    const nonDuplicateCourses = courses.filter(
+      (incoming) =>
+        !selectedCourses.some(
+          (existing) =>
+            existing.courseId === incoming.courseId && existing.semesterId === incoming.semesterId,
+        ),
+    );
+
+    setSelectedCourses([...selectedCourses, ...nonDuplicateCourses]);
+  };
+
+  const handleRemoveSelectedCourse = (course: SelectedCourse) => {
+    setSelectedCourses(
+      selectedCourses.filter(
+        ({ courseId, semesterId }) =>
+          course.courseId !== courseId && course.semesterId !== semesterId,
+      ),
+    );
+  };
+
+  const [semesters, dispatchSemesters] = useReducer<
     (state: SemestersReducerState, action: SemestersReducerAction) => Semester[]
   >(
     (state, action) => {
@@ -96,6 +156,12 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
 
             return semester;
           });
+
+        case 'deleteAllCoursesFromSemester':
+          return state.map((semester) =>
+            semester.id.toString() === action.semesterId ? { ...semester, courses: [] } : semester,
+          );
+
         default:
           return state;
       }
@@ -122,13 +188,24 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
 
   const deleteYear = trpc.plan.deleteYear.useMutation();
 
+  const deleteAllCourses = trpc.plan.deleteAllCoursesFromSemester.useMutation();
+
+  const handleDeleteAllCoursesFromSemester = (semester: Semester) => {
+    dispatchSemesters({ type: 'deleteAllCoursesFromSemester', semesterId: semester.id.toString() });
+
+    addTask({
+      func: ({ semesterId }) => deleteAllCourses.mutateAsync({ semesterId }),
+      args: { semesterId: semester.id.toString() },
+    });
+  };
+
   const handleAddYear = () => {
     const newYear: Semester[] = createNewYear(
       semesters.length ? semesters[semesters.length - 1].code : { semester: 'u', year: 2022 },
     );
     const semesterIds = newYear.map((sem) => sem.id);
 
-    dispatch({ type: 'addSemesters', newSemesters: newYear });
+    dispatchSemesters({ type: 'addSemesters', newSemesters: newYear });
 
     addTask({
       func: ({ semesterIds }) =>
@@ -151,7 +228,7 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
   };
 
   const handleRemoveYear = () => {
-    dispatch({ type: 'removeYear' });
+    dispatchSemesters({ type: 'removeYear' });
 
     addTask({
       func: () =>
@@ -176,7 +253,7 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
     targetSemester: Semester,
     targetCourse: DraggableCourse,
   ) => {
-    dispatch({
+    dispatchSemesters({
       type: 'removeCourseFromSemester',
       courseId: targetCourse.id.toString(),
       semesterId: targetSemester.id.toString(),
@@ -219,7 +296,7 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
     const semesterId = targetSemester.id.toString();
     const courseName = newCourse.code;
 
-    dispatch({ type: 'addCourseToSemester', semesterId, newCourse });
+    dispatchSemesters({ type: 'addCourseToSemester', semesterId, newCourse });
 
     addTask({
       func: ({ semesterId, courseName }) =>
@@ -257,7 +334,7 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
     const newSemesterId = destinationSemester.id.toString();
     const courseName = courseToMove.code;
 
-    dispatch({
+    dispatchSemesters({
       type: 'moveCourseFromSemesterToSemester',
       originSemesterId: oldSemesterId,
       destinationSemesterId: newSemesterId,
@@ -282,18 +359,25 @@ const useSemesters = ({ plan, planId }: useSemestersProps): useSemestersReturn =
       args: { oldSemesterId, newSemesterId, courseName },
     });
   };
-
-  return {
-    semesters: sortedSemesters,
-    handleAddCourseToSemester,
-    handleAddYear,
-    handleMoveCourseFromSemesterToSemester,
-    handleRemoveCourseFromSemester,
-    handleRemoveYear,
-  };
+  return (
+    <SemestersContext.Provider
+      value={{
+        semesters: sortedSemesters,
+        selectedCourseCount: selectedCourses.length,
+        handleAddSelectedCourses,
+        handleRemoveSelectedCourse,
+        handleAddCourseToSemester,
+        handleAddYear,
+        handleMoveCourseFromSemesterToSemester,
+        handleRemoveCourseFromSemester,
+        handleRemoveYear,
+        handleDeleteAllCoursesFromSemester,
+      }}
+    >
+      {children}
+    </SemestersContext.Provider>
+  );
 };
-
-export default useSemesters;
 
 const parsePlanSemestersFromPlan = (plan: Plan): Semester[] => {
   return plan.semesters.map((sem) => ({

--- a/src/components/planner/SortByDropdown.tsx
+++ b/src/components/planner/SortByDropdown.tsx
@@ -16,7 +16,7 @@ const SortByDropdown: FC = () => {
       <DropdownMenu.Trigger asChild>
         <button aria-label="Sort by options">
           <Button size="large" color="secondary" icon={<SwitchVerticalIcon />} className="mr-8">
-            Sort By
+            <span className="whitespace-nowrap">Sort By</span>
           </Button>
         </button>
       </DropdownMenu.Trigger>

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -6,9 +6,11 @@ import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import { displaySemesterCode } from '@/utils/utilFunctions';
 import CheckIcon from '@mui/icons-material/Check';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import Checkbox from '@/components/Checkbox';
 
 export interface SemesterCourseItemProps extends ComponentPropsWithoutRef<'div'> {
   course: DraggableCourse;
+  isSelected?: boolean;
   isTransfer?: boolean;
   onSelectCourse?: () => void;
   onDeselectCourse?: () => void;
@@ -18,25 +20,13 @@ export interface SemesterCourseItemProps extends ComponentPropsWithoutRef<'div'>
 /* eslint-disable react/prop-types */
 export const MemoizedSemesterCourseItem = React.memo(
   forwardRef<HTMLDivElement, SemesterCourseItemProps>(function SemesterCourseItem(
-    { course, isTransfer, onSelectCourse, onDeselectCourse, ...props },
+    { course, isTransfer, onSelectCourse, onDeselectCourse, isSelected, ...props },
     ref,
   ) {
     // Create text output for sync icon
     const correctSemester = course.sync?.correctSemester
       ? `Course already taken in ${displaySemesterCode(course.sync?.correctSemester)}`
       : `No record of this course in Course History`;
-
-    const [checked, setChecked] = useState(false);
-
-    const updateChecked = () => {
-      if (!checked) {
-        onSelectCourse && onSelectCourse();
-        setChecked(true);
-      } else {
-        onDeselectCourse && onDeselectCourse();
-        setChecked(false);
-      }
-    };
 
     return (
       <div
@@ -47,10 +37,18 @@ export const MemoizedSemesterCourseItem = React.memo(
       >
         <div className="flex items-center gap-x-3">
           <DragIndicatorIcon fontSize="inherit" className="text-[16px] text-neutral-300" />
-          <input
-            onChange={() => updateChecked()}
-            type="checkbox"
-            className="checkbox-primary checkbox h-5 w-5 rounded-[3.5px] border-1.25 border-neutral-300 bg-generic-white accent-primary"
+          <Checkbox
+            style={{ width: '20px', height: '20px' }}
+            checked={isSelected}
+            onCheckedChange={(checked) => {
+              if (checked && onSelectCourse) {
+                onSelectCourse();
+              }
+
+              if (!checked && onDeselectCourse) {
+                onDeselectCourse();
+              }
+            }}
           />
           <span className="text-[16px] text-[#1C2A6D]">{course.code}</span>
         </div>
@@ -81,6 +79,7 @@ export const SemesterCourseItem = MemoizedSemesterCourseItem;
 
 export interface DraggableSemesterCourseItemProps {
   dragId: UniqueIdentifier;
+  isSelected: boolean;
   semester: Semester;
   course: DraggableCourse;
   onSelectCourse: () => void;
@@ -94,6 +93,7 @@ const DraggableSemesterCourseItem: FC<DraggableSemesterCourseItemProps> = ({
   course,
   onSelectCourse,
   onDeselectCourse,
+  isSelected,
 }) => {
   const { setNodeRef, attributes, listeners, isDragging } = useDraggable({
     id: dragId,
@@ -111,6 +111,7 @@ const DraggableSemesterCourseItem: FC<DraggableSemesterCourseItemProps> = ({
       course={course}
       onSelectCourse={onSelectCourse}
       onDeselectCourse={onDeselectCourse}
+      isSelected={isSelected}
     />
   );
 };

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -1,5 +1,5 @@
 import { UniqueIdentifier, useDraggable } from '@dnd-kit/core';
-import { ComponentPropsWithoutRef, FC, forwardRef, useState } from 'react';
+import React, { ComponentPropsWithoutRef, FC, forwardRef, useState } from 'react';
 
 import { DragDataFromSemesterTile, DraggableCourse, Semester } from '../types';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
@@ -15,8 +15,9 @@ export interface SemesterCourseItemProps extends ComponentPropsWithoutRef<'div'>
 }
 
 /** UI implementation of a semester course */
-export const SemesterCourseItem = forwardRef<HTMLDivElement, SemesterCourseItemProps>(
-  function SemesterCourseItem(
+/* eslint-disable react/prop-types */
+export const MemoizedSemesterCourseItem = React.memo(
+  forwardRef<HTMLDivElement, SemesterCourseItemProps>(function SemesterCourseItem(
     { course, isTransfer, onSelectCourse, onDeselectCourse, ...props },
     ref,
   ) {
@@ -73,8 +74,10 @@ export const SemesterCourseItem = forwardRef<HTMLDivElement, SemesterCourseItemP
         </div>
       </div>
     );
-  },
+  }),
 );
+
+export const SemesterCourseItem = MemoizedSemesterCourseItem;
 
 export interface DraggableSemesterCourseItemProps {
   dragId: UniqueIdentifier;
@@ -112,4 +115,4 @@ const DraggableSemesterCourseItem: FC<DraggableSemesterCourseItemProps> = ({
   );
 };
 
-export default DraggableSemesterCourseItem;
+export default React.memo(DraggableSemesterCourseItem);

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -1,8 +1,5 @@
 import { UniqueIdentifier, useDraggable } from '@dnd-kit/core';
-import CloseIcon from '@mui/icons-material/Close';
-import { ComponentPropsWithoutRef, FC, forwardRef } from 'react';
-
-import { getStartingPlanSemester, isEarlierSemester } from '@/utils/plannerUtils';
+import { ComponentPropsWithoutRef, FC, forwardRef, useState } from 'react';
 
 import { DragDataFromSemesterTile, DraggableCourse, Semester } from '../types';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
@@ -12,18 +9,33 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 
 export interface SemesterCourseItemProps extends ComponentPropsWithoutRef<'div'> {
   course: DraggableCourse;
-  isValid?: boolean;
   isTransfer?: boolean;
-  onRemove?: (course: DraggableCourse) => void;
+  onSelectCourse?: () => void;
+  onDeselectCourse?: () => void;
 }
 
 /** UI implementation of a semester course */
 export const SemesterCourseItem = forwardRef<HTMLDivElement, SemesterCourseItemProps>(
-  function SemesterCourseItem({ course, isValid, isTransfer, onRemove, ...props }, ref) {
+  function SemesterCourseItem(
+    { course, isTransfer, onSelectCourse, onDeselectCourse, ...props },
+    ref,
+  ) {
     // Create text output for sync icon
     const correctSemester = course.sync?.correctSemester
       ? `Course already taken in ${displaySemesterCode(course.sync?.correctSemester)}`
       : `No record of this course in Course History`;
+
+    const [checked, setChecked] = useState(false);
+
+    const updateChecked = () => {
+      if (!checked) {
+        onSelectCourse && onSelectCourse();
+        setChecked(true);
+      } else {
+        onDeselectCourse && onDeselectCourse();
+        setChecked(false);
+      }
+    };
 
     return (
       <div
@@ -35,6 +47,7 @@ export const SemesterCourseItem = forwardRef<HTMLDivElement, SemesterCourseItemP
         <div className="flex items-center gap-x-3">
           <DragIndicatorIcon fontSize="inherit" className="text-[16px] text-neutral-300" />
           <input
+            onChange={() => updateChecked()}
             type="checkbox"
             className="checkbox-primary checkbox h-5 w-5 rounded-[3.5px] border-1.25 border-neutral-300 bg-generic-white accent-primary"
           />
@@ -67,8 +80,8 @@ export interface DraggableSemesterCourseItemProps {
   dragId: UniqueIdentifier;
   semester: Semester;
   course: DraggableCourse;
-  isValid: boolean;
-  onRemove: (course: DraggableCourse) => void;
+  onSelectCourse: () => void;
+  onDeselectCourse: () => void;
 }
 
 /** Compositional wrapper around SemesterCourseItem */
@@ -76,7 +89,8 @@ const DraggableSemesterCourseItem: FC<DraggableSemesterCourseItemProps> = ({
   dragId,
   semester,
   course,
-  onRemove,
+  onSelectCourse,
+  onDeselectCourse,
 }) => {
   const { setNodeRef, attributes, listeners, isDragging } = useDraggable({
     id: dragId,
@@ -92,7 +106,8 @@ const DraggableSemesterCourseItem: FC<DraggableSemesterCourseItemProps> = ({
       {...attributes}
       {...listeners}
       course={course}
-      onRemove={onRemove}
+      onSelectCourse={onSelectCourse}
+      onDeselectCourse={onDeselectCourse}
     />
   );
 };

--- a/src/components/planner/Tiles/SemesterTile.tsx
+++ b/src/components/planner/Tiles/SemesterTile.tsx
@@ -1,5 +1,5 @@
 import { UniqueIdentifier, useDroppable } from '@dnd-kit/core';
-import { FC, forwardRef, useState } from 'react';
+import React, { FC, forwardRef, useState } from 'react';
 
 import { displaySemesterCode } from '@/utils/utilFunctions';
 
@@ -19,103 +19,108 @@ export interface SemesterTileProps {
 /**
  * Strictly UI implementation of a semester tile
  */
-export const SemesterTile = forwardRef<HTMLDivElement, SemesterTileProps>(function SemesterTile(
-  { semester, getDragId, semesterErrors },
-  ref,
-) {
-  const [open, setOpen] = useState(true);
+/* eslint-disable react/prop-types */
+export const MemoizedSemesterTile = React.memo(
+  forwardRef<HTMLDivElement, SemesterTileProps>(function SemesterTile(
+    { semester, getDragId, semesterErrors },
+    ref,
+  ) {
+    const [open, setOpen] = useState(true);
 
-  const {
-    handleAddSelectedCourses,
-    handleRemoveSelectedCourse,
-    handleDeleteAllCoursesFromSemester,
-  } = useSemestersContext();
+    const {
+      handleAddSelectedCourses,
+      handleRemoveSelectedCourse,
+      handleDeleteAllCoursesFromSemester,
+    } = useSemestersContext();
 
-  const { sync, prerequisites } = semesterErrors;
-  const { extra, missing } = sync;
+    const { sync, prerequisites } = semesterErrors;
+    const { extra, missing } = sync;
 
-  const numProblems = extra.length + missing.length + prerequisites.length;
+    const numProblems = extra.length + missing.length + prerequisites.length;
 
-  const generateErrorMsg = () => {
-    const extraMsg = extra.length > 0 ? `Extra courses: ${extra.toString()}. ` : '';
-    const missingMsg = missing.length > 0 ? `Missing courses: ${missing.toString()}. ` : '';
-    const prerequisiteMsg = undefined; // TODO: Implement later
+    const generateErrorMsg = () => {
+      const extraMsg = extra.length > 0 ? `Extra courses: ${extra.toString()}. ` : '';
+      const missingMsg = missing.length > 0 ? `Missing courses: ${missing.toString()}. ` : '';
+      const prerequisiteMsg = undefined; // TODO: Implement later
 
-    return `Errors found in semester: ${extraMsg}${missingMsg}`;
-  };
+      return `Errors found in semester: ${extraMsg}${missingMsg}`;
+    };
 
-  // QUESTION: isValid color?
-  return (
-    <div
-      ref={ref}
-      className={`flex h-fit w-[369px] select-none flex-col gap-y-4 overflow-hidden rounded-2xl border border-neutral-300 bg-white py-4 px-5`}
-    >
-      <article className="w-full">
-        <ChevronIcon
-          className={`${
-            open ? 'rotate-90' : '-rotate-90'
-          } ml-auto h-3 w-3 transform cursor-pointer text-neutral-500 transition-all duration-500`}
-          fontSize="inherit"
-          onClick={() => setOpen(!open)}
-        />
-      </article>
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex h-10 flex-row items-center justify-center">
-          <h3 className={`text-2xl font-semibold text-primary-900`}>
-            {displaySemesterCode(semester.code)}
-          </h3>
+    // QUESTION: isValid color?
+    return (
+      <div
+        ref={ref}
+        className={`flex h-fit w-[369px] select-none flex-col gap-y-4 overflow-hidden rounded-2xl border border-neutral-300 bg-white py-4 px-5`}
+      >
+        <article className="w-full">
+          <ChevronIcon
+            className={`${
+              open ? 'rotate-90' : '-rotate-90'
+            } ml-auto h-3 w-3 transform cursor-pointer text-neutral-500 transition-all duration-500`}
+            fontSize="inherit"
+            onClick={() => setOpen(!open)}
+          />
+        </article>
+        <div className="flex flex-row items-center justify-between">
+          <div className="flex h-10 flex-row items-center justify-center">
+            <h3 className={`text-2xl font-semibold text-primary-900`}>
+              {displaySemesterCode(semester.code)}
+            </h3>
+          </div>
+
+          {numProblems > 0 && (
+            <div
+              className="opacity-0.5 tooltip tooltip-top h-fit rounded-full text-[14px] font-medium "
+              data-tip={`${generateErrorMsg()}`}
+            >
+              <div className="badge border-none bg-red-50 text-red-500">{numProblems} errors</div>
+            </div>
+          )}
+
+          <SemesterTileDropdown
+            deleteAllCourses={() => handleDeleteAllCoursesFromSemester(semester)}
+            selectAllCourses={() =>
+              handleAddSelectedCourses(
+                semester.courses.map((course) => ({
+                  courseId: course.id.toString(),
+                  semesterId: semester.id.toString(),
+                })),
+              )
+            }
+          />
         </div>
 
-        {numProblems > 0 && (
-          <div
-            className="opacity-0.5 tooltip tooltip-top h-fit rounded-full text-[14px] font-medium "
-            data-tip={`${generateErrorMsg()}`}
-          >
-            <div className="badge border-none bg-red-50 text-red-500">{numProblems} errors</div>
-          </div>
-        )}
-
-        <SemesterTileDropdown
-          deleteAllCourses={() => handleDeleteAllCoursesFromSemester(semester)}
-          selectAllCourses={() =>
-            handleAddSelectedCourses(
-              semester.courses.map((course) => ({
-                courseId: course.id.toString(),
-                semesterId: semester.id.toString(),
-              })),
-            )
-          }
-        />
+        <article
+          className={`flex flex-col gap-y-4 overflow-hidden transition-all duration-700 ${
+            open ? 'max-h-[999px]' : 'max-h-0'
+          }`}
+        >
+          {semester.courses.map((course) => (
+            <DraggableSemesterCourseItem
+              onSelectCourse={() =>
+                handleAddSelectedCourses([
+                  { courseId: course.id.toString(), semesterId: semester.id.toString() },
+                ])
+              }
+              onDeselectCourse={() =>
+                handleRemoveSelectedCourse({
+                  courseId: course.id.toString(),
+                  semesterId: semester.id.toString(),
+                })
+              }
+              key={course.id.toString()}
+              dragId={getDragId(course, semester)}
+              course={course}
+              semester={semester}
+            />
+          ))}
+        </article>
       </div>
+    );
+  }),
+);
 
-      <article
-        className={`flex flex-col gap-y-4 overflow-hidden transition-all duration-700 ${
-          open ? 'max-h-[999px]' : 'max-h-0'
-        }`}
-      >
-        {semester.courses.map((course) => (
-          <DraggableSemesterCourseItem
-            onSelectCourse={() =>
-              handleAddSelectedCourses([
-                { courseId: course.id.toString(), semesterId: semester.id.toString() },
-              ])
-            }
-            onDeselectCourse={() =>
-              handleRemoveSelectedCourse({
-                courseId: course.id.toString(),
-                semesterId: semester.id.toString(),
-              })
-            }
-            key={course.id.toString()}
-            dragId={getDragId(course, semester)}
-            course={course}
-            semester={semester}
-          />
-        ))}
-      </article>
-    </div>
-  );
-});
+export const SemesterTile = MemoizedSemesterTile;
 
 export interface DroppableSemesterTileProps {
   dropId: UniqueIdentifier;
@@ -148,4 +153,4 @@ const DroppableSemesterTile: FC<DroppableSemesterTileProps> = ({
   );
 };
 
-export default DroppableSemesterTile;
+export default React.memo(DroppableSemesterTile);

--- a/src/components/planner/Tiles/SemesterTile.tsx
+++ b/src/components/planner/Tiles/SemesterTile.tsx
@@ -28,9 +28,10 @@ export const MemoizedSemesterTile = React.memo(
     const [open, setOpen] = useState(true);
 
     const {
-      handleAddSelectedCourses,
-      handleRemoveSelectedCourse,
+      handleSelectCourses,
+      handleDeselectCourses,
       handleDeleteAllCoursesFromSemester,
+      courseIsSelected,
     } = useSemestersContext();
 
     const { sync, prerequisites } = semesterErrors;
@@ -80,12 +81,7 @@ export const MemoizedSemesterTile = React.memo(
           <SemesterTileDropdown
             deleteAllCourses={() => handleDeleteAllCoursesFromSemester(semester)}
             selectAllCourses={() =>
-              handleAddSelectedCourses(
-                semester.courses.map((course) => ({
-                  courseId: course.id.toString(),
-                  semesterId: semester.id.toString(),
-                })),
-              )
+              handleSelectCourses(semester.courses.map((course) => course.id.toString()))
             }
           />
         </div>
@@ -97,17 +93,10 @@ export const MemoizedSemesterTile = React.memo(
         >
           {semester.courses.map((course) => (
             <DraggableSemesterCourseItem
-              onSelectCourse={() =>
-                handleAddSelectedCourses([
-                  { courseId: course.id.toString(), semesterId: semester.id.toString() },
-                ])
-              }
-              onDeselectCourse={() =>
-                handleRemoveSelectedCourse({
-                  courseId: course.id.toString(),
-                  semesterId: semester.id.toString(),
-                })
-              }
+              isSelected={courseIsSelected(course.id.toString())}
+              // isSelected={true}
+              onSelectCourse={() => handleSelectCourses([course.id.toString()])}
+              onDeselectCourse={() => handleDeselectCourses([course.id.toString()])}
               key={course.id.toString()}
               dragId={getDragId(course, semester)}
               course={course}

--- a/src/components/planner/Tiles/SemesterTileDropdown.tsx
+++ b/src/components/planner/Tiles/SemesterTileDropdown.tsx
@@ -11,7 +11,15 @@ const itemClasses =
 
 const contentClasses = 'w-64 rounded-md border border-neutral-300 bg-generic-white';
 
-const SemesterTileDropdown: FC = () => {
+export interface SemesterTileDropdownProps {
+  deleteAllCourses: () => void;
+  selectAllCourses: () => void;
+}
+
+const SemesterTileDropdown: FC<SemesterTileDropdownProps> = ({
+  deleteAllCourses,
+  selectAllCourses,
+}) => {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
@@ -26,11 +34,11 @@ const SemesterTileDropdown: FC = () => {
           sideOffset={10}
           align="start"
         >
-          <DropdownMenu.Item className={itemClasses}>
+          <DropdownMenu.Item className={itemClasses} onClick={deleteAllCourses}>
             <ArchiveIcon />
             <span>Clear courses</span>
           </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClasses}>
+          <DropdownMenu.Item className={itemClasses} onClick={selectAllCourses}>
             <ClipboardListIcon />
             <span>Select all courses</span>
           </DropdownMenu.Item>

--- a/src/components/planner/Toolbar.tsx
+++ b/src/components/planner/Toolbar.tsx
@@ -3,15 +3,17 @@ import DownloadIcon from '@/icons/DownloadIcon';
 import EditIcon from '@/icons/EditIcon';
 import { FC } from 'react';
 import Button from '../Button';
-import Toggle from '../Toggle';
+import Switch from '../Switch';
 import SortByDropdown from './SortByDropdown';
 
 export interface ToolbarProps {
   title: string;
   major: string;
+  showTransfer: boolean;
+  toggleShowTransfer: (show: boolean) => void;
 }
 
-const Toolbar: FC<ToolbarProps> = ({ title, major }) => {
+const Toolbar: FC<ToolbarProps> = ({ title, major, showTransfer, toggleShowTransfer }) => {
   return (
     <section className="flex w-full flex-col justify-center gap-y-6">
       <article className="flex justify-between">
@@ -32,7 +34,12 @@ const Toolbar: FC<ToolbarProps> = ({ title, major }) => {
         </button>
 
         <form className="flex items-center gap-x-3">
-          <Toggle size="small" id="transfer-toggle" />
+          <Switch
+            size="small"
+            id="transfer-toggle"
+            checked={showTransfer}
+            onCheckedChange={toggleShowTransfer}
+          />
           <label htmlFor="transfer-toggle" className="text-base text-neutral-900">
             Show Transfer Credits
           </label>

--- a/src/components/planner/Toolbar.tsx
+++ b/src/components/planner/Toolbar.tsx
@@ -22,7 +22,7 @@ const Toolbar: FC<ToolbarProps> = ({ title, major, showTransfer, toggleShowTrans
           <SortByDropdown />
           <Button size="large" icon={<AddFileIcon className="h-6 w-5" />} />
           <Button size="large" icon={<DownloadIcon />}>
-            Export Degree Plan
+            <span className="whitespace-nowrap">Export Degree Plan</span>
           </Button>
         </div>
       </article>

--- a/src/icons/CheckIcon.tsx
+++ b/src/icons/CheckIcon.tsx
@@ -1,0 +1,26 @@
+import { FC, SVGProps } from 'react';
+
+const CheckIcon: FC<SVGProps<SVGSVGElement>> = (props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="12"
+      fill="none"
+      viewBox="0 0 16 12"
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        fill="#fff"
+        fillRule="evenodd"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M14.38 1.085c.23.21.244.566.035.795l-8.25 9a.562.562 0 01-.813.018l-3.75-3.75a.562.562 0 11.796-.796l3.334 3.335 7.853-8.567a.563.563 0 01.795-.035z"
+        clipRule="evenodd"
+      ></path>
+    </svg>
+  );
+};
+
+export default CheckIcon;

--- a/src/icons/CursorClickIcon.tsx
+++ b/src/icons/CursorClickIcon.tsx
@@ -1,0 +1,24 @@
+import { FC, SVGProps } from 'react';
+
+const CursorClickIcon: FC<SVGProps<SVGSVGElement>> = (props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.67"
+        d="M11.059 11.059L9.482 15 6.33 6.33 15 9.482l-3.941 1.577zm0 0L15 15M4.902 1l.612 2.284m-2.23 2.23L1 4.902m9.231-2.474L8.559 4.1M4.1 8.56L2.428 10.23"
+      ></path>
+    </svg>
+  );
+};
+
+export default CursorClickIcon;

--- a/src/icons/DeleteIcon.tsx
+++ b/src/icons/DeleteIcon.tsx
@@ -1,0 +1,24 @@
+import { FC, SVGProps } from 'react';
+
+const DeleteIcon: FC<SVGProps<SVGSVGElement>> = (props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.67"
+        d="M13.444 4.111l-.674 9.444A1.556 1.556 0 0111.218 15H4.782c-.816 0-1.494-.63-1.552-1.445l-.674-9.444m3.888 3.111v4.667m3.112-4.667v4.667m.777-7.778V1.778A.778.778 0 009.556 1H6.445a.778.778 0 00-.778.778V4.11m-3.89 0h12.445"
+      ></path>
+    </svg>
+  );
+};
+
+export default DeleteIcon;

--- a/src/pages/app/plans/[planId].tsx
+++ b/src/pages/app/plans/[planId].tsx
@@ -1,4 +1,3 @@
-import { PDFDownloadLink } from '@react-pdf/renderer';
 import { createProxySSGHelpers } from '@trpc/react-query/ssg';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next/types';
 import { getServerSession } from 'next-auth';
@@ -6,7 +5,6 @@ import { useSession } from 'next-auth/react';
 import { useState } from 'react';
 import superjson from 'superjson';
 
-import DegreePlanPDF from '@/components/planner/DegreePlanPDF/DegreePlanPDF';
 import Planner from '@/components/planner/Planner';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { createContextInner } from '@/server/trpc/context';
@@ -24,10 +22,6 @@ export default function PlanDetailPage(
   const { planId } = props;
   const { plan, validation, isLoading, handlePlanDelete } = usePlan({ planId });
 
-  const [showTransfer, setShowTransfer] = useState(true);
-
-  const { data: session } = useSession();
-
   // Indicate UI loading
   if (isLoading) {
     return <div>Loading</div>;
@@ -37,7 +31,7 @@ export default function PlanDetailPage(
     <div className="flex h-screen max-h-screen w-screen flex-col overflow-x-hidden overflow-y-scroll p-4">
       {plan && validation && (
         <SemestersContextProvider planId={planId} plan={plan}>
-          <Planner degreeRequirements={validation} showTransfer={showTransfer} />
+          <Planner degreeRequirements={validation} />
         </SemestersContextProvider>
       )}
       <button onClick={handlePlanDelete}>Delete</button>

--- a/src/pages/app/plans/[planId].tsx
+++ b/src/pages/app/plans/[planId].tsx
@@ -35,43 +35,6 @@ export default function PlanDetailPage(
 
   return (
     <div className="flex h-screen max-h-screen w-screen flex-col overflow-x-hidden overflow-y-scroll p-4">
-      {/* <div className=" mb-10 flex flex-row items-center gap-2">
-        <div className="text-2xl">My Plan</div>
-
-        <div className="form-control">
-          <label className="label cursor-pointer">
-            <span className="label-text">Show Transfer Credits</span>
-            <input
-              type="checkbox"
-              className="toggle-success toggle"
-              onClick={() => setShowTransfer(!showTransfer)}
-              defaultChecked
-            />
-          </label>
-        </div>
-
-        <div className=" ml-auto">Majors: Computer Science</div>
-
-        <div>Minors: Cognitive Science</div>
-        <div>Fast Track</div>
-        <div>Import Plan</div>
-        {plan && (
-          <PDFDownloadLink
-            className="text-base font-normal"
-            document={
-              <DegreePlanPDF
-                studentName={session?.user?.email || ''}
-                planTitle={plan.name}
-                semesters={semesters}
-              />
-            }
-            fileName={plan.name + '.pdf'}
-          >
-            {({ loading }) => (loading ? 'Loading document...' : 'EXPORT PLAN')}
-          </PDFDownloadLink>
-        )}
-        <SettingsIcon className={`ml-5 h-5 w-5 cursor-pointer`} strokeWidth={2.5} />
-      </div> */}
       {plan && validation && (
         <SemestersContextProvider planId={planId} plan={plan}>
           <Planner degreeRequirements={validation} showTransfer={showTransfer} />

--- a/src/pages/app/plans/[planId].tsx
+++ b/src/pages/app/plans/[planId].tsx
@@ -8,12 +8,11 @@ import superjson from 'superjson';
 
 import DegreePlanPDF from '@/components/planner/DegreePlanPDF/DegreePlanPDF';
 import Planner from '@/components/planner/Planner';
-import SettingsIcon from '@/icons/SettingsIcon';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { createContextInner } from '@/server/trpc/context';
 import { appRouter } from '@/server/trpc/router/_app';
 import usePlan from '@/components/planner/usePlan';
-import useSemesters from '@/components/planner/useSemesters';
+import { SemestersContextProvider } from '@/components/planner/SemesterContext';
 
 /**
  * A page that displays the details of a specific student academic plan.
@@ -24,14 +23,6 @@ export default function PlanDetailPage(
 ): JSX.Element {
   const { planId } = props;
   const { plan, validation, isLoading, handlePlanDelete } = usePlan({ planId });
-  const {
-    semesters,
-    handleAddCourseToSemester,
-    handleAddYear,
-    handleMoveCourseFromSemesterToSemester,
-    handleRemoveCourseFromSemester,
-    handleRemoveYear,
-  } = useSemesters({ plan, planId });
 
   const [showTransfer, setShowTransfer] = useState(true);
 
@@ -44,7 +35,7 @@ export default function PlanDetailPage(
 
   return (
     <div className="flex h-screen max-h-screen w-screen flex-col overflow-x-hidden overflow-y-scroll p-4">
-      <div className=" mb-10 flex flex-row items-center gap-2">
+      {/* <div className=" mb-10 flex flex-row items-center gap-2">
         <div className="text-2xl">My Plan</div>
 
         <div className="form-control">
@@ -80,17 +71,12 @@ export default function PlanDetailPage(
           </PDFDownloadLink>
         )}
         <SettingsIcon className={`ml-5 h-5 w-5 cursor-pointer`} strokeWidth={2.5} />
-      </div>
-      <Planner
-        degreeRequirements={validation}
-        semesters={semesters}
-        showTransfer={showTransfer}
-        handleAddCourseToSemester={handleAddCourseToSemester}
-        handleAddYear={handleAddYear}
-        handleMoveCourseFromSemesterToSemester={handleMoveCourseFromSemesterToSemester}
-        handleRemoveCourseFromSemester={handleRemoveCourseFromSemester}
-        handleRemoveYear={handleRemoveYear}
-      />
+      </div> */}
+      {plan && validation && (
+        <SemestersContextProvider planId={planId} plan={plan}>
+          <Planner degreeRequirements={validation} showTransfer={showTransfer} />
+        </SemestersContextProvider>
+      )}
       <button onClick={handlePlanDelete}>Delete</button>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,6 +74,17 @@ module.exports = {
             transform: 'translateX(0)',
           },
         },
+        checkboxCheckmark: {
+          '0%': {
+            transform: 'translateY(20px)',
+          },
+          '75%': {
+            transform: 'translateY(-2px)',
+          },
+          '100%': {
+            transform: 'translateY(0)',
+          },
+        },
       },
       animation: {
         hide: 'fadeInTwo 1s ease-in-out',


### PR DESCRIPTION
- [x] Moves semesters state into context
- [x] Add memoization
- [x] Introduces selectable courses

Why? Prop drilling was getting deep (imagine 2x for each droppable semester tile AND draggable courses, so prop drilling 4 levels).

Possible issues:
- When selecting courses, unnecessary rerenders. IMO this is okay because no one needs optimization when clicking a select button.
- When changing semesters, will cause double rerender from top level useContext and useContext deeper within the tree. I think we can take this hit. Frankly a few extra rerenders doesn't sound so bad when you consider useDraggable was causing 100s of rerenders during dragging.