### PR TITLE
Use custom sensor to prevent dragging interactive elements

### DIFF
--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -13,7 +13,6 @@
 import {
   DndContext,
   DragOverlay,
-  MouseSensor,
   pointerWithin,
   useSensor,
   useSensors,
@@ -38,6 +37,7 @@ import Toolbar from './Toolbar';
 import { useSemestersContext } from './SemesterContext';
 import SelectedCoursesToast from './SelectedCoursesToast';
 import TransferBank from './TransferBank';
+import PlannerMouseSensor from './PlannerMouseSensor';
 
 /** PlannerTool Props */
 export interface PlannerProps {
@@ -68,7 +68,7 @@ export default function Planner({
   // Delay necessary so events inside draggables propagate
   // valid sensors: https://github.com/clauderic/dnd-kit/discussions/82#discussioncomment-347608
   const sensors = useSensors(
-    useSensor(MouseSensor, {
+    useSensor(PlannerMouseSensor, {
       activationConstraint: {
         distance: 1,
       },

--- a/src/components/planner/PlannerMouseSensor.ts
+++ b/src/components/planner/PlannerMouseSensor.ts
@@ -1,0 +1,27 @@
+import type { MouseEvent } from 'react'
+import { MouseSensor } from '@dnd-kit/core';
+
+export default class PlannerMouseSensor extends MouseSensor {
+  static activators = [
+    {
+      eventName: 'onMouseDown' as const,
+      handler: ({ nativeEvent: event }: MouseEvent) => {
+        return shouldHandleEvent(event.target as HTMLElement);
+      },
+    },
+  ];
+}
+
+function shouldHandleEvent(element: HTMLElement | null) {
+    let cur = element;
+    
+    while (cur) {
+        console.log({cur})
+        if (cur.dataset && cur.dataset.noDnd) {
+      return false;
+    }
+    cur = cur.parentElement;
+  }
+
+  return true;
+}

--- a/src/components/planner/PlannerMouseSensor.ts
+++ b/src/components/planner/PlannerMouseSensor.ts
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react'
+import type { MouseEvent } from 'react';
 import { MouseSensor } from '@dnd-kit/core';
 
 export default class PlannerMouseSensor extends MouseSensor {
@@ -13,11 +13,11 @@ export default class PlannerMouseSensor extends MouseSensor {
 }
 
 function shouldHandleEvent(element: HTMLElement | null) {
-    let cur = element;
-    
-    while (cur) {
-        console.log({cur})
-        if (cur.dataset && cur.dataset.noDnd) {
+  let cur = element;
+
+  while (cur) {
+    console.log({ cur });
+    if (cur.dataset && cur.dataset.noDnd) {
       return false;
     }
     cur = cur.parentElement;

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -54,7 +54,7 @@ export const MemoizedSemesterCourseItem = React.memo(
               <Checkbox
                 style={{ width: '20px', height: '20px' }}
                 checked={isSelected}
-                onClick={(e)=>e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
                 onCheckedChange={(checked) => {
                   if (checked && onSelectCourse) {
                     onSelectCourse();

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -54,6 +54,7 @@ export const MemoizedSemesterCourseItem = React.memo(
               <Checkbox
                 style={{ width: '20px', height: '20px' }}
                 checked={isSelected}
+                onClick={(e)=>e.stopPropagation()}
                 onCheckedChange={(checked) => {
                   if (checked && onSelectCourse) {
                     onSelectCourse();

--- a/src/components/planner/Tiles/SemesterCourseItemDropdown.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItemDropdown.tsx
@@ -62,7 +62,7 @@ const SemesterCourseItemDropdown: FC<SemesterTileDropdownProps> = ({
 
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
-              data-no-dnd="true"
+                data-no-dnd="true"
                 className={contentClasses + ' animate-[slideLeftAndFade_0.3s]'}
                 sideOffset={-10}
                 alignOffset={0}

--- a/src/components/planner/Tiles/SemesterCourseItemDropdown.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItemDropdown.tsx
@@ -29,7 +29,7 @@ const SemesterCourseItemDropdown: FC<SemesterTileDropdownProps> = ({
   const id = new ObjectID().toString();
   return (
     <DropdownMenu.Root open={open} onOpenChange={onOpenChange}>
-      <DropdownMenu.Trigger asChild>
+      <DropdownMenu.Trigger data-no-dnd="true" asChild>
         <button className="cursor-pointer rounded-md py-[2px] transition-all duration-300 hover:bg-neutral-100">
           <DragIndicatorIcon fontSize="inherit" className="text-[16px] text-neutral-300" />
         </button>
@@ -37,6 +37,7 @@ const SemesterCourseItemDropdown: FC<SemesterTileDropdownProps> = ({
 
       <DropdownMenu.Portal>
         <DropdownMenu.Content
+          data-no-dnd="true"
           className={contentClasses + ' animate-[slideUpAndFade_0.3s]'}
           sideOffset={10}
           align="start"
@@ -61,6 +62,7 @@ const SemesterCourseItemDropdown: FC<SemesterTileDropdownProps> = ({
 
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
+              data-no-dnd="true"
                 className={contentClasses + ' animate-[slideLeftAndFade_0.3s]'}
                 sideOffset={-10}
                 alignOffset={0}


### PR DESCRIPTION
This PR kinda fixes #439 - changing colors works in Firefox, however for some reason the tag has a 0px height when set to use `height: 100%;`... but works perfectly when set to a absolute height?? and it works fine in chrome... Will need to look into this later