### PR TITLE
NP-36 (Change locked course on plan editor to match the OG UI)

### DIFF
--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -132,7 +132,7 @@ export const MemoizedSemesterCourseItem = React.memo(
             <div className="flex w-[calc(100%-8rem)] flex-col">
               <span className="content-middle flex items-center whitespace-nowrap text-sm">
                 {course.code}
-                {!isValid && !course.prereqOveridden && (
+                {!isValid && !course.prereqOveridden && !course.locked && (
                   <PrereqWarnHoverCard
                     prereqs={requirementsData === undefined ? [[], [], []] : requirementsData}
                     description={description ?? ''}
@@ -142,7 +142,7 @@ export const MemoizedSemesterCourseItem = React.memo(
                     isOverriden={course.prereqOveridden}
                   >
                     <span className="text-[#FBBF24]" onMouseLeave={() => setPrereqWarnOpen(false)}>
-                      <FilledWarningIcon />
+                      {!semesterLocked && <FilledWarningIcon />}
                     </span>
                   </PrereqWarnHoverCard>
                 )}

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -72,17 +72,18 @@ export const MemoizedSemesterCourseItem = React.memo(
           !isValid && !course.prereqOveridden ? 'bg-[#FEFBED]' : 'bg-[#FFFFFF]'
         }  ${
           !course.locked || isValid || isValid === undefined
-            ? course.locked
-              ? 'bg-neutral-200'
+            ? course.locked || semesterLocked
+              ? 'cursor-default bg-neutral-200'
               : 'bg-inherit'
-            : 'bg-[#FFFBEB]'
+            : 'cursor-default bg-neutral-200'
         } ${semesterLocked || course.locked ? 'text-neutral-400' : 'text-[#1C2A6D]'}`}
         onClick={() => {
           // Don't open if user is hovering over course info
-          setDropdownOpen(true);
+          if (!course.locked && !semesterLocked) setDropdownOpen(true);
         }}
         onMouseEnter={() => {
-          if (!dropdownOpen) hoverTimer.current = setTimeout(() => setHoverOpen(true), 500);
+          if (!dropdownOpen && !course.locked && !semesterLocked)
+            hoverTimer.current = setTimeout(() => setHoverOpen(true), 500);
           setHoverEllipse(true);
         }}
         onMouseLeave={() => {
@@ -109,21 +110,25 @@ export const MemoizedSemesterCourseItem = React.memo(
         >
           <div className="flex w-full flex-row items-center gap-x-3">
             <DragIndicatorIcon fontSize="inherit" className="text-[16px] text-neutral-300" />
-            <Checkbox
-              disabled={course.locked}
-              style={{ minWidth: '20px', height: '20px', backgroundColor: 'inherit' }}
-              checked={isSelected}
-              onClick={(e) => e.stopPropagation()}
-              onCheckedChange={(checked) => {
-                if (checked && onSelectCourse) {
-                  onSelectCourse();
-                }
+            {course.locked || semesterLocked ? (
+              <LockIcon className="ml-1" />
+            ) : (
+              <Checkbox
+                disabled={course.locked}
+                style={{ minWidth: '20px', height: '20px', backgroundColor: 'inherit' }}
+                checked={isSelected}
+                onClick={(e) => e.stopPropagation()}
+                onCheckedChange={(checked) => {
+                  if (checked && onSelectCourse) {
+                    onSelectCourse();
+                  }
 
-                if (!checked && onDeselectCourse) {
-                  onDeselectCourse();
-                }
-              }}
-            />
+                  if (!checked && onDeselectCourse) {
+                    onDeselectCourse();
+                  }
+                }}
+              />
+            )}
             <div className="flex w-[calc(100%-8rem)] flex-col">
               <span className="content-middle flex items-center whitespace-nowrap text-sm">
                 {course.code}
@@ -141,39 +146,44 @@ export const MemoizedSemesterCourseItem = React.memo(
                     </span>
                   </PrereqWarnHoverCard>
                 )}
-                {course.locked && <LockIcon className="ml-1" />}
               </span>
               <span className="truncate text-sm">{title}</span>
             </div>
-            <SemesterCourseItemDropdown
-              open={dropdownOpen}
-              onOpenChange={(open) => {
-                if (hoverOpen) {
-                  setHoverOpen(false);
+            {!semesterLocked && (
+              <SemesterCourseItemDropdown
+                open={dropdownOpen}
+                onOpenChange={(open) => {
+                  if (hoverOpen) {
+                    setHoverOpen(false);
+                  }
+                  if (!open) setHoverEllipse(false);
+                  setDropdownOpen(open);
+                }}
+                locked={course.locked}
+                onPrereqOverrideChange={() =>
+                  onPrereqOverrideChange && onPrereqOverrideChange(!course.prereqOveridden)
                 }
-                if (!open) setHoverEllipse(false);
-                setDropdownOpen(open);
-              }}
-              locked={course.locked}
-              onPrereqOverrideChange={() =>
-                onPrereqOverrideChange && onPrereqOverrideChange(!course.prereqOveridden)
-              }
-              isValid={isValid}
-              prereqOverriden={course.prereqOveridden}
-              semesterLocked={semesterLocked || false}
-              toggleLock={() => onLockChange && onLockChange(!course.locked)}
-              changeColor={(color) => onColorChange && onColorChange(color)}
-              deleteCourse={() => onDeleteCourse && onDeleteCourse()}
-            >
-              <div
-                className="mr-2 rounded-md px-2 py-3 hover:bg-gray-200/[.5]"
-                onClick={() => setDropdownOpen(true)}
+                isValid={isValid}
+                prereqOverriden={course.prereqOveridden}
+                semesterLocked={semesterLocked || false}
+                toggleLock={() => onLockChange && onLockChange(!course.locked)}
+                changeColor={(color) => onColorChange && onColorChange(color)}
+                deleteCourse={() => onDeleteCourse && onDeleteCourse()}
               >
-                <DotsHorizontalIcon
-                  className={`h-auto w-5 ${hoverEllipse || dropdownOpen ? '' : 'invisible'}`}
-                />
-              </div>
-            </SemesterCourseItemDropdown>
+                <div
+                  className={`mr-2 rounded-md px-2 py-3 hover:cursor-default ${
+                    course.locked ? 'hover:bg-gray-300' : 'hover:bg-gray-200/[.5]'
+                  }`}
+                  onClick={() => setDropdownOpen(true)}
+                >
+                  {!semesterLocked && (
+                    <DotsHorizontalIcon
+                      className={`h-auto w-5 ${hoverEllipse || dropdownOpen ? '' : 'invisible'}`}
+                    />
+                  )}
+                </div>
+              </SemesterCourseItemDropdown>
+            )}
           </div>
         </CourseInfoHoverCard>
       </div>

--- a/src/components/planner/Tiles/SemesterCourseItemDropdown.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItemDropdown.tsx
@@ -68,7 +68,7 @@ const SemesterCourseItemDropdown: FC<SemesterTileDropdownProps> = ({
             <span>Delete</span>
           </DropdownMenu.Item>
 
-          {!isValid && (
+          {!isValid && !locked && (
             <DropdownMenu.Item className={itemClasses} onClick={onPrereqOverrideChange}>
               <UnfilledWarningIcon stroke="black" />
               <span>{prereqOverriden ? 'Show Pre-reqs Warning' : 'Dismiss Pre-reqs Warning'}</span>


### PR DESCRIPTION
## Overview

Resolves NP-36

## What Changed

Changed locked courses to match the original UI. (SemesterCourseItem.tsx)

While course is locked:
- Matched background colors
- Disabled course info hover card 
- Checkbox disabled and replaced with lock icon
- Cursor set to default
- Horizontal Dots Icon made darker for visibility, default cursor on hover

While semester is locked:
- Course Items unclickable
- Horizontal Dots Icon disabled and removed
- Pre-Req yellow background removed for courses with warning

## Other Notes

Some enhancements were made based on my opinion, please let me know if anything needs to be changed!
