### PR TITLE
Impelement Skeleton UI in Sidebar/Course Item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "prettier-eslint": "^13.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-loading-skeleton": "^3.3.1",
         "react-toastify": "^9.1.1",
         "superjson": "^1.11.0",
         "tss-react": "^3.3.6",
@@ -13863,6 +13864,14 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
+    },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.3.1.tgz",
+      "integrity": "sha512-NilqqwMh2v9omN7LteiDloEVpFyMIa0VGqF+ukqp0ncVlYu1sKYbYGX9JEl+GtOT9TKsh04zCHAbavnQ2USldA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/react-reconciler": {
       "version": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prettier-eslint": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-loading-skeleton": "^3.3.1",
     "react-toastify": "^9.1.1",
     "superjson": "^1.11.0",
     "tss-react": "^3.3.6",

--- a/src/components/planner/Sidebar/AccordionSkeleton.tsx
+++ b/src/components/planner/Sidebar/AccordionSkeleton.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+export default function AccordionSkeleton() {
+  return (
+    <>
+      <div className={`flex justify-center rounded-2xl border p-6`}>
+        <Skeleton width={200} className={`flex-1 grow`} />
+      </div>
+      <div className={`flex justify-center rounded-2xl border p-6`}>
+        <Skeleton width={200} className={`flex-1 grow`} />
+      </div>
+    </>
+  );
+}

--- a/src/components/planner/Sidebar/Sidebar.tsx
+++ b/src/components/planner/Sidebar/Sidebar.tsx
@@ -1,20 +1,23 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useRef, useState, useMemo, memo } from 'react';
+import Skeleton from 'react-loading-skeleton';
 import { v4 as uuidv4 } from 'uuid';
+
+import AccordionSkeleton from './AccordionSkeleton';
+import DraggableCourseList from './DraggableCourseList';
+import { DegreeRequirement } from './types';
+import { Course, DraggableCourse, GetDragIdByCourse } from '../types';
+import useFuse from '../useFuse';
 
 import Button from '@/components/Button';
 import AnalyticsWrapper from '@/components/common/AnalyticsWrapper';
 import RequirementsContainer from '@/components/planner/Sidebar/RequirementsContainer';
 import SearchBar from '@/components/planner/Sidebar/SearchBar';
-import Spinner from '@/components/Spinner';
 import ChevronIcon from '@/icons/ChevronIcon';
 import { trpc } from '@/utils/trpc';
 import { getSemesterHourFromCourseCode } from '@/utils/utilFunctions';
 
-import DraggableCourseList from './DraggableCourseList';
-import { DegreeRequirement } from './types';
-import { Course, DraggableCourse, GetDragIdByCourse } from '../types';
-import useFuse from '../useFuse';
+import 'react-loading-skeleton/dist/skeleton.css';
 
 export interface CourseSelectorContainerProps {
   planId: string;
@@ -96,7 +99,11 @@ function CourseSelectorContainer({
             taken >= min ? 'text-primary-800' : 'text-yellow-500'
           }`}
         >
-          {taken}/{min} {unit}
+          {taken != -1 ? (
+            taken + '/' + min + ' ' + unit
+          ) : (
+            <Skeleton inline={true} width={100} className={`flex-1`} />
+          )}
         </span>
       </div>
     );
@@ -128,7 +135,7 @@ function CourseSelectorContainer({
                   </h1>
                 </div>
                 <div id="tutorial-editor-2">
-                  {validationData && !isValidationLoading && (
+                  {validationData ? (
                     <CreditsTaken
                       taken={sum}
                       min={
@@ -137,6 +144,8 @@ function CourseSelectorContainer({
                           : 120
                       }
                     />
+                  ) : (
+                    <CreditsTaken taken={-1} min={-1} />
                   )}
                 </div>
               </div>
@@ -176,30 +185,15 @@ function CourseSelectorContainer({
                     className="z-[999]"
                     onOpenAutoFocus={(e) => e.preventDefault()}
                   >
-                    {!isLoading ? (
-                      <div className="w-full border-[2px] border-[#EDEFF7] bg-white p-4 drop-shadow-2xl">
-                        <DraggableCourseList
-                          courses={courseResults}
-                          getDragId={getSearchedDragId}
-                        />
-                      </div>
-                    ) : (
-                      <div className="p-4 text-base text-[#757575]">
-                        Please wait, courses are loading....
-                      </div>
-                    )}
+                    <div className="w-full border-[2px] border-[#EDEFF7] bg-white p-4 drop-shadow-2xl">
+                      <DraggableCourseList courses={courseResults} getDragId={getSearchedDragId} />
+                    </div>
                   </Dialog.Content>
                 </Dialog.Portal>
               )}
             </Dialog.Root>
 
-            {isValidationLoading && (
-              <div className="flex flex-grow items-center justify-center">
-                <Spinner size="large" />
-              </div>
-            )}
-
-            {!isValidationLoading && error?.data?.code === 'INTERNAL_SERVER_ERROR' && (
+            {error?.data?.code === 'INTERNAL_SERVER_ERROR' && (
               <div className="flex h-[30vh] w-full text-base leading-5 text-[#A3A3A3]">
                 <div className="mx-12 mt-44 flex w-full flex-col items-center justify-center gap-4 text-center leading-6">
                   It seems like a screw has gone loose!
@@ -210,8 +204,7 @@ function CourseSelectorContainer({
               </div>
             )}
 
-            {!isValidationLoading &&
-              validationData &&
+            {validationData &&
               validationData.validation.requirements.length > 0 &&
               validationData.validation.requirements.map((req: DegreeRequirement, idx: number) => (
                 <RequirementsContainer
@@ -221,6 +214,7 @@ function CourseSelectorContainer({
                   getCourseItemDragId={getRequirementDragId}
                 />
               ))}
+            {!validationData && <AccordionSkeleton />}
             <div className="flex flex-grow items-end justify-end text-sm ">
               <div>
                 <span className="font-bold">Warning:</span> This is an unofficial tool not

--- a/src/components/planner/Tiles/SemesterCourseItem.tsx
+++ b/src/components/planner/Tiles/SemesterCourseItem.tsx
@@ -1,12 +1,7 @@
 import { UniqueIdentifier, useDraggable } from '@dnd-kit/core';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import React, { ComponentPropsWithoutRef, FC, forwardRef, useState, useRef } from 'react';
-
-import Checkbox from '@/components/Checkbox';
-import DotsHorizontalIcon from '@/icons/DotsHorizontalIcon';
-import FilledWarningIcon from '@/icons/FilledWarningIcon';
-import LockIcon from '@/icons/LockIcon';
-import { trpc } from '@/utils/trpc';
+import Skeleton from 'react-loading-skeleton';
 
 import SemesterCourseItemDropdown from './SemesterCourseItemDropdown';
 import CourseInfoHoverCard from '../CourseInfoHoverCard';
@@ -15,6 +10,14 @@ import { useSemestersContext } from '../SemesterContext';
 import { DragDataFromSemesterTile, DraggableCourse, Semester } from '../types';
 import useGetCourseInfo from '../useGetCourseInfo';
 import { tagColors } from '../utils';
+
+import Checkbox from '@/components/Checkbox';
+import DotsHorizontalIcon from '@/icons/DotsHorizontalIcon';
+import FilledWarningIcon from '@/icons/FilledWarningIcon';
+import LockIcon from '@/icons/LockIcon';
+import { trpc } from '@/utils/trpc';
+
+import 'react-loading-skeleton/dist/skeleton.css';
 
 export interface SemesterCourseItemProps extends ComponentPropsWithoutRef<'div'> {
   course: DraggableCourse;
@@ -147,7 +150,9 @@ export const MemoizedSemesterCourseItem = React.memo(
                   </PrereqWarnHoverCard>
                 )}
               </span>
-              <span className="truncate text-sm">{title}</span>
+              <span className="truncate text-sm">
+                {title || (course.code[0] == '0' ? '' : <Skeleton />)}
+              </span>
             </div>
             {!semesterLocked && (
               <SemesterCourseItemDropdown

--- a/src/components/planner/Toolbar/Toolbar.tsx
+++ b/src/components/planner/Toolbar/Toolbar.tsx
@@ -3,13 +3,6 @@ import { usePDF } from '@react-pdf/renderer';
 import Link from 'next/link';
 import { FC, useEffect, useState } from 'react';
 
-import AnalyticsWrapper from '@/components/common/AnalyticsWrapper';
-import DownloadIcon from '@/icons/DownloadIcon';
-import SettingsIcon from '@/icons/SettingsIcon';
-import SwitchVerticalIcon from '@/icons/SwitchVerticalIcon';
-import DeletePlanModal from '@/shared/DeletePlanModal';
-import { trpc } from '@/utils/trpc';
-
 import EditableMajorTitle from './EditablePlanTitle';
 import EditSemestersModal from './EditSemestersModal';
 import FilterByDropdown from './FilterByDropdown';
@@ -18,6 +11,13 @@ import Button from '../../Button';
 import DegreePlanPDF from '../DegreePlanPDF/DegreePlanPDF';
 import EditableMajor from '../EditableMajor';
 import { useSemestersContext } from '../SemesterContext';
+
+import AnalyticsWrapper from '@/components/common/AnalyticsWrapper';
+import DownloadIcon from '@/icons/DownloadIcon';
+import SettingsIcon from '@/icons/SettingsIcon';
+import SwitchVerticalIcon from '@/icons/SwitchVerticalIcon';
+import DeletePlanModal from '@/shared/DeletePlanModal';
+import { trpc } from '@/utils/trpc';
 
 export interface ToolbarProps {
   degreeRequirements: { id: string; major: string };
@@ -95,7 +95,7 @@ const Toolbar: FC<ToolbarProps> = ({
             >
               <Button
                 size="medium"
-                isLoading={loading}
+                isLoading={false}
                 disabled={!!error}
                 icon={<DownloadIcon />}
                 id="tutorial-editor-7"

--- a/src/server/db/platform_client.ts
+++ b/src/server/db/platform_client.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '../../../prisma/generated/platform/';
+import { PrismaClient } from '../../../prisma/generated/platform';
 import { env } from '../../env/server.mjs';
 declare global {
   // eslint-disable-next-line no-var


### PR DESCRIPTION
## Overview

Adds a loading animation to the course titles in the sidebar/drag 'n drop menu. Removes the loading conditional for the "Export Degree Plan" button because its UI doesn't depend on plan/course data.

## What Changed

Removes the previous loading screens, like the spinner or loading text, in CourseSelectorContainer. Creates a skeleton component for the accordion, and replaces text with a skeleton based on a conditional in all other cases.
