### PR TITLE
NP-24 Restrict sidebar auto-scrolling

### DIFF
--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -147,7 +147,7 @@ export default function Planner({
         );
       }
     }
-    
+
     setIsCourseDragging(false);
   };
 

--- a/src/components/planner/Planner.tsx
+++ b/src/components/planner/Planner.tsx
@@ -93,6 +93,9 @@ export default function Planner({
   // Course that is currently being dragged
   const [activeCourse, setActiveCourse] = useState<ActiveDragData | null>(null);
 
+  // Controls drag locking for the sidebar
+  const [isCourseDragging, setIsCourseDragging] = useState(false);
+
   // Delay necessary so events inside draggables propagate
   // valid sensors: https://github.com/clauderic/dnd-kit/discussions/82#discussioncomment-347608
   const sensors = useSensors(
@@ -116,6 +119,7 @@ export default function Planner({
   const handleOnDragStart = ({ active }: { active: Active }) => {
     const originData = active.data.current as DragEventOriginData;
     setActiveCourse({ from: originData.from, course: originData.course });
+    setIsCourseDragging(true);
   };
 
   const handleOnDragEnd = ({ active, over }: { active: Active; over: Over | null }) => {
@@ -143,6 +147,8 @@ export default function Planner({
         );
       }
     }
+    
+    setIsCourseDragging(false);
   };
 
   const ref = useRef<HTMLDivElement>(null);
@@ -150,8 +156,7 @@ export default function Planner({
 
   return (
     <DndContext
-      // Enabling autoScroll causes odd behavior when dragging outside of a scrollable container (eg. Sidebar)
-      autoScroll={false}
+      autoScroll={true}
       sensors={sensors}
       collisionDetection={pointerWithin}
       onDragStart={handleOnDragStart}
@@ -218,6 +223,7 @@ export default function Planner({
           transferCredits={transferCredits}
           getSearchedDragId={(course) => `course-list-searched-${course.id}`}
           getRequirementDragId={(course) => `course-list-requirement-${course.id}`}
+          courseDragged={isCourseDragging}
         />
       </div>
     </DndContext>

--- a/src/components/planner/Sidebar/Sidebar.tsx
+++ b/src/components/planner/Sidebar/Sidebar.tsx
@@ -25,6 +25,7 @@ export interface CourseSelectorContainerProps {
   transferCredits: string[];
   getSearchedDragId: GetDragIdByCourse;
   getRequirementDragId: GetDragIdByCourse;
+  courseDragged: boolean;
 }
 
 function CourseSelectorContainer({
@@ -33,6 +34,7 @@ function CourseSelectorContainer({
   transferCredits,
   getSearchedDragId,
   getRequirementDragId,
+  courseDragged,
 }: CourseSelectorContainerProps) {
   const {
     data: validationData,
@@ -119,7 +121,9 @@ function CourseSelectorContainer({
       {open ? (
         <div
           id="tutorial-editor-1"
-          className="z-0 h-screen w-[30%] min-w-[30%] overflow-x-hidden overflow-y-scroll"
+          className={`z-0 h-screen w-[30%] min-w-[30%] overflow-x-hidden ${
+            courseDragged ? 'overflow-y-hidden' : 'overflow-y-scroll'
+          }`}
         >
           <div className="flex h-fit min-h-screen w-full flex-col gap-y-4 bg-white p-4">
             <div className="flex flex-col">


### PR DESCRIPTION
## Overview

Fixes NP-24. Previously, when a course was dragged to the bottom of the planner screen the sidebar would scroll as well. This is because the way DndContext is defined. This fix restricts the sidebar from scrolling when a course is being dragged, so only the planner component can auto-scroll.

## What Changed

Added a courseDragged prop to sidebar that determines whether or not is should be able to scroll. If a course is being dragged, then y-overflow is hidden on the sidebar object.

## Other Notes

This creates a small visual issue where the sidebar must disappear while the scrolling is restricted. I couldn't find a solution to this using tailwind, but it isn't that noticeable of an issue.