### PR TITLE
NP-128 (Unlocked courses from another semester should not be able to be dragged into locked semester)

### DIFF
--- a/src/components/planner/Tiles/SemesterTile.tsx
+++ b/src/components/planner/Tiles/SemesterTile.tsx
@@ -208,6 +208,7 @@ const DroppableSemesterTile: FC<DroppableSemesterTileProps> = ({
   const { setNodeRef } = useDroppable({
     id: dropId,
     data: { to: 'semester-tile', semester } as DragDataToSemesterTile,
+    disabled: semester.locked,
   });
 
   return (


### PR DESCRIPTION
## Overview

Resolves NP-128
Fixes bug that allowed courses to be dragged into locked semster. 

## What Changed

(SemesterTile.tsx)
Added disabled argument into useDroppable to temporarily disable the droppable area when the semester is locked. 
