### PR TITLE
Fix(NP-92) Changing file to read binary

### DIFF
--- a/validator/scripts/diff.py
+++ b/validator/scripts/diff.py
@@ -83,8 +83,8 @@ def createTicket(issueType: str, jira_connection: JIRA, URI: str, coursesImpacte
         labels=["Engineering"],
     )
     if os.path.getsize("description.txt"):
-        with open("description.txt", "rb") as f:
-            jira_connection.add_attachment(issue=ticket, attachment=f)
+        with open("description.txt", "rb") as descriptionFile:
+            jira_connection.add_attachment(issue=ticket, attachment=descriptionFile)
     os.remove("description.txt")
 
 #Establishes JIRA connection and ierates through each major for versioning issues

--- a/validator/scripts/diff.py
+++ b/validator/scripts/diff.py
@@ -82,10 +82,9 @@ def createTicket(issueType: str, jira_connection: JIRA, URI: str, coursesImpacte
         customfield_10016=1,
         labels=["Engineering"],
     )
-    f = open("description.txt", "r")
     if os.path.getsize("description.txt"):
-        jira_connection.add_attachment(issue=ticket, attachment=f)
-    f.close()
+        with open("description.txt", "rb") as f:
+            jira_connection.add_attachment(issue=ticket, attachment=f)
     os.remove("description.txt")
 
 #Establishes JIRA connection and ierates through each major for versioning issues


### PR DESCRIPTION
## Overview

Changed how the txt file is sent to JIRA (rb) using with open notation. Testing locally allowed the tickets to be created, so this should be the final fix.