### PR TITLE
Only send relevant info about courses to frontend

### DIFF
--- a/src/components/planner/DegreePlanPDF/DegreePlanPDF.tsx
+++ b/src/components/planner/DegreePlanPDF/DegreePlanPDF.tsx
@@ -9,8 +9,6 @@ import Header from './Header';
 import { Semester } from '../types';
 import { customCourseSort } from '../utils';
 
-import type { Prisma } from '@prisma/client';
-
 Font.register({
   family: 'Inter',
   fonts: [

--- a/src/components/planner/DegreePlanPDF/DegreePlanPDF.tsx
+++ b/src/components/planner/DegreePlanPDF/DegreePlanPDF.tsx
@@ -50,9 +50,7 @@ interface DegreePlanPDFProps {
   transferCredits: string[];
   coursesData: {
     title: string;
-    id: string;
     course_number: string;
-    prerequisites: Prisma.JsonValue;
     subject_prefix: string;
   }[];
 }
@@ -199,9 +197,7 @@ const convertSemestersToAcademicYears = (
   semesters: Semester[],
   coursesData: {
     title: string;
-    id: string;
     course_number: string;
-    prerequisites: Prisma.JsonValue;
     subject_prefix: string;
   }[],
 ) => {
@@ -283,9 +279,7 @@ const addCoursesToSemester = (
   semester: Semester,
   coursesData: {
     title: string;
-    id: string;
     course_number: string;
-    prerequisites: Prisma.JsonValue;
     subject_prefix: string;
   }[],
 ) => {

--- a/src/components/planner/Sidebar/RequirementsContainer.tsx
+++ b/src/components/planner/Sidebar/RequirementsContainer.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 
 import useSearch from '@/components/search/search';
 import { trpc } from '@/utils/trpc';
-import { courses as Course } from 'prisma/generated/platform';
+import { MinimalCourse } from '@server/trpc/router/courseCache';
 
 import Accordion from './Accordion';
 import { RecursiveRequirement } from './RecursiveRequirement';
@@ -76,7 +76,7 @@ function RequirementContainerHeader({
 
 const getRequirementGroup = (
   degreeRequirement: RequirementGroupTypes,
-  allCourses: Course[] | undefined,
+  allCourses: MinimalCourse[] | undefined,
 ): {
   name: string;
   progress: { value: number; max: number; unit: string };

--- a/src/components/planner/useGetCourseInfo.ts
+++ b/src/components/planner/useGetCourseInfo.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { RouterOutputs, trpc } from '@/utils/trpc';
 
 // TODO: Change implementation
@@ -7,9 +5,6 @@ import { RouterOutputs, trpc } from '@/utils/trpc';
 const useGetCourseInfo = (
   courseCode: string,
 ): {
-  prereqs: string[];
-  coreqs: string[];
-  co_or_pre: string[];
   title?: string;
   description?: string;
 } => {
@@ -18,136 +13,30 @@ const useGetCourseInfo = (
     cacheTime: Infinity,
     refetchOnWindowFocus: false,
   });
-  const { prereqs, coreqs, co_or_pre, title } = useMemo(
-    () => (data ? getPrereqs(data, courseCode) : { prereqs: [], coreqs: [], co_or_pre: [] }),
-    [data, courseCode],
-  );
+  if (data === undefined) return {};
+  const title = getTitle(data, courseCode);
 
   // Get course description
-  const description = useMemo(() => {
-    const courseInfo = data?.find(
-      (course) => course.subject_prefix + ' ' + course.course_number === courseCode,
-    );
+  const courseInfo = data?.find(
+    (course) => course.subject_prefix + ' ' + course.course_number === courseCode,
+  );
+  const description = courseInfo ? courseInfo.description : '';
 
-    return courseInfo ? courseInfo.description : '';
-  }, [data, courseCode]);
-
-  return { prereqs, coreqs, co_or_pre, title, description };
+  return { title, description };
 };
 
 export default useGetCourseInfo;
 
 type CourseData = RouterOutputs['courses']['publicGetAllCourses'];
 
-const getPrereqs = (
-  courseData: CourseData,
-  courseCode: string,
-): { prereqs: string[]; coreqs: string[]; co_or_pre: string[]; title?: string } => {
-  const prereqs: string[] = [];
-  const coreqs: string[] = [];
-  const co_or_pre: string[] = [];
-
+const getTitle = (courseData: CourseData, courseCode: string): string | undefined => {
   let title;
   courseData?.find(function (cNum) {
     if (cNum.subject_prefix + ' ' + cNum.course_number === courseCode) {
       title = cNum.title;
-
-      cNum.prerequisites?.options.map((elem) => {
-        if (elem.type !== 'course' && elem.type !== 'other' && elem.options) {
-          elem.options.map((elem2) => {
-            if (elem2.type !== 'course' && elem2.type !== 'other') {
-              elem2.options?.map((elem3) => {
-                courseData?.map((elem4) => {
-                  if (elem4.id === elem3.class_reference) {
-                    prereqs.push(elem4.subject_prefix + ' ' + elem4.course_number);
-                  }
-                });
-              });
-            } else if (elem2.type === 'other') {
-              prereqs.push(elem2.description || '');
-            } else {
-              courseData?.map((elem4) => {
-                if (elem4.id === elem2.class_reference) {
-                  prereqs.push(elem4.subject_prefix + ' ' + elem4.course_number);
-                }
-              });
-            }
-          });
-        } else if (elem.type === 'other') {
-          prereqs.push(elem.description || '');
-        } else {
-          courseData?.map((elem4) => {
-            if (elem4.id === elem.class_reference) {
-              prereqs.push(elem4.subject_prefix + ' ' + elem4.course_number);
-            }
-          });
-        }
-      });
-      cNum.corequisites?.options.map((elem) => {
-        if (elem.type !== 'course' && elem.type !== 'other' && elem.options) {
-          elem.options.map((elem2) => {
-            if (elem2.type !== 'course' && elem2.type !== 'other') {
-              elem2.options?.map((elem3) => {
-                courseData?.map((elem4) => {
-                  if (elem4.id === elem3.class_reference) {
-                    coreqs.push(elem4.subject_prefix + ' ' + elem4.course_number);
-                  }
-                });
-              });
-            } else if (elem2.type === 'other') {
-              coreqs.push(elem2.description || '');
-            } else {
-              courseData?.map((elem4) => {
-                if (elem4.id === elem2.class_reference) {
-                  coreqs.push(elem4.subject_prefix + ' ' + elem4.course_number);
-                }
-              });
-            }
-          });
-        } else if (elem.type === 'other') {
-          coreqs.push(elem.description || '');
-        } else {
-          courseData?.map((elem4) => {
-            if (elem4.id === elem.class_reference) {
-              coreqs.push(elem4.subject_prefix + ' ' + elem4.course_number);
-            }
-          });
-        }
-      });
-      cNum.co_or_pre_requisites?.options.map((elem) => {
-        if (elem.type !== 'course' && elem.type !== 'other' && elem.options) {
-          elem.options.map((elem2) => {
-            if (elem2.type !== 'course' && elem2.type !== 'other') {
-              elem2.options?.map((elem3) => {
-                courseData?.map((elem4) => {
-                  if (elem4.id === elem3.class_reference) {
-                    co_or_pre.push(elem4.subject_prefix + ' ' + elem4.course_number);
-                  }
-                });
-              });
-            } else if (elem2.type === 'other') {
-              co_or_pre.push(elem2.description || '');
-            } else {
-              courseData?.map((elem4) => {
-                if (elem4.id === elem2.class_reference) {
-                  co_or_pre.push(elem4.subject_prefix + ' ' + elem4.course_number);
-                }
-              });
-            }
-          });
-        } else if (elem.type === 'other') {
-          co_or_pre.push(elem.description || '');
-        } else {
-          courseData?.map((elem4) => {
-            if (elem4.id === elem.class_reference) {
-              co_or_pre.push(elem4.subject_prefix + ' ' + elem4.course_number);
-            }
-          });
-        }
-      });
       return courseCode;
     }
   });
 
-  return { prereqs, coreqs, co_or_pre, title };
+  return title;
 };

--- a/src/server/trpc/router/courseCache.ts
+++ b/src/server/trpc/router/courseCache.ts
@@ -7,7 +7,7 @@ class CourseCacheError extends Error {
   name = 'CourseCacheError';
 }
 
-interface MinimalCourse {
+export interface MinimalCourse {
   title: string;
   description: string;
   subject_prefix: string;

--- a/src/server/trpc/router/courseCache.ts
+++ b/src/server/trpc/router/courseCache.ts
@@ -7,9 +7,18 @@ class CourseCacheError extends Error {
   name = 'CourseCacheError';
 }
 
+interface MinimalCourse {
+  title: string;
+  description: string;
+  subject_prefix: string;
+  course_number: string;
+}
+
 class CourseCache {
-  private coursesByYear: Map<number, Course[]> = new Map();
+  private coursesByYear: Map<number, MinimalCourse[]> = new Map();
+  private courseWithReqsByYear: Map<number, Course[]> = new Map();
   private mutex = new Mutex();
+  private mutexReqs = new Mutex();
 
   public async getCourses(year: number) {
     // Acquire lock before success check so if another request is fetching, we don't fetch again.
@@ -24,9 +33,36 @@ class CourseCache {
     return await platformPrisma.courses
       .findMany({
         distinct: ['title', 'course_number', 'subject_prefix'],
+        select: { title: true, description: true, subject_prefix: true, course_number: true },
       })
       .then((courses) => {
         this.coursesByYear.set(year, courses);
+        return courses;
+      })
+      .catch((err) => {
+        const message = `Error fetching courses for year ${year}: ${err}`;
+        console.error(message);
+        throw new CourseCacheError(message, { cause: err });
+      })
+      .finally(release);
+  }
+
+  public async getCourseReqs(year: number) {
+    // Acquire lock before success check so if another request is fetching, we don't fetch again.
+    const release = await this.mutexReqs.acquire();
+    if (this.courseWithReqsByYear.has(year)) {
+      release();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return this.courseWithReqsByYear.get(year)!; // Must exist at this point
+    }
+
+    console.info(`Fetching courses for year ${year}...`);
+    return await platformPrisma.courses
+      .findMany({
+        distinct: ['title', 'course_number', 'subject_prefix'],
+      })
+      .then((courses) => {
+        this.courseWithReqsByYear.set(year, courses);
         return courses;
       })
       .catch((err) => {

--- a/src/server/trpc/router/courses.ts
+++ b/src/server/trpc/router/courses.ts
@@ -7,29 +7,4 @@ export const coursesRouter = router({
   publicGetAllCourses: publicProcedure.query(async () => {
     return await courseCache.getCourses(new Date().getFullYear());
   }),
-  publicGetSanitizedCourses: publicProcedure.query(async ({ ctx }) => {
-    const courses = await ctx.platformPrisma.courses.findMany({
-      select: {
-        course_number: true,
-        subject_prefix: true,
-        id: true,
-        prerequisites: true,
-        corequisites: true,
-      },
-    });
-
-    const courseMapWithIdKey = new Map<string, Prisma.JsonValue>();
-    const courseMapWithCodeKey = new Map<string, Prisma.JsonValue>();
-
-    for (const course of courses) {
-      courseMapWithCodeKey.set(`${course.subject_prefix} ${course.course_number}`, {
-        prereq: course.prerequisites,
-        coreq: course.corequisites,
-      });
-      courseMapWithIdKey.set(course.id, `${course.subject_prefix} ${course.course_number}`);
-    }
-    // print the map
-
-    return courseMapWithCodeKey;
-  }),
 });

--- a/src/server/trpc/router/courses.ts
+++ b/src/server/trpc/router/courses.ts
@@ -1,5 +1,3 @@
-import { Prisma } from '@prisma/client';
-
 import { courseCache } from './courseCache';
 import { router, publicProcedure } from '../trpc';
 

--- a/src/server/trpc/router/validator.ts
+++ b/src/server/trpc/router/validator.ts
@@ -32,7 +32,7 @@ export const validatorRouter = router({
         year = Math.min(...planData.semesters.map((sem) => sem.year));
       }
 
-      const coursesFromAPI: PlatformCourse[] = await courseCache.getCourses(year);
+      const coursesFromAPI: PlatformCourse[] = await courseCache.getCourseReqs(year);
       /*  sanitizing data from API db.
        *  TODO: Fix this later somehow
        */

--- a/validator/degree_data/2022/Psychology(BS).json
+++ b/validator/degree_data/2022/Psychology(BS).json
@@ -233,12 +233,7 @@
             "metadata": {
               "id": "Psychology(BS)-29"
             },
-            "accepted_prefixes": [
-              "PSY",
-              "CGS",
-              "CLDP",
-              "NSC"
-            ]
+            "accepted_prefixes": ["PSY", "CGS", "CLDP", "NSC"]
           }
         ]
       },


### PR DESCRIPTION
Should fix issue that currently breaks develop - the size of the response from trpc function that returns info about courses is too big. This commit will change it so the trpc function only returns relevant fields, and there's a separate server-side function that includes pre and coreqs for use by validator.ts