### PR TITLE
Sentry only on prod

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -68,4 +68,11 @@ module.exports = (phase, args) =>
     // https://docs.sentry.io/product/crons/
     // https://vercel.com/docs/cron-jobs
     automaticVercelMonitors: true,
+
+    sourcemaps: {
+      disable: process.env.VERCEL_ENV !== 'production',
+    },
+    release: {
+      create: process.env.VERCEL_ENV === 'production',
+    },
   });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,7 +6,8 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: 'https://a8f2aec35998f8b8f4f0cafd73e3951d@o4504918397353984.ingest.us.sentry.io/4509436341518336',
+  // Kept in an environment variable to only enable in prod
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,7 +5,8 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: 'https://a8f2aec35998f8b8f4f0cafd73e3951d@o4504918397353984.ingest.us.sentry.io/4509436341518336',
+  // Kept in an environment variable to only enable in prod
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,7 +5,8 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: 'https://a8f2aec35998f8b8f4f0cafd73e3951d@o4504918397353984.ingest.us.sentry.io/4509436341518336',
+  // Kept in an environment variable to only enable in prod
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [


### PR DESCRIPTION
Only enable Sentry on production deployments, to avoid sending errors for local development or on preview deployments.